### PR TITLE
Fix the resolve options for a browser target

### DIFF
--- a/src/services/configurations/pluginsConfiguration.js
+++ b/src/services/configurations/pluginsConfiguration.js
@@ -240,12 +240,15 @@ class RollupPluginSettingsConfiguration extends ConfigurationFile {
    * @ignore
    */
   _getResolveSettings(params) {
+    const { target } = params;
     const settings = {
       // Add just for basic JS files and JSON.
       extensions: ['.js', '.json', '.jsx'],
+      browser: target.is.browser,
+      preferBuiltins: target.is.node,
     };
 
-    const eventName = params.target.is.node ?
+    const eventName = target.is.node ?
       'rollup-resolve-plugin-settings-configuration-for-node' :
       'rollup-resolve-plugin-settings-configuration-for-browser';
 

--- a/tests/services/configurations/pluginsConfiguration.test.js
+++ b/tests/services/configurations/pluginsConfiguration.test.js
@@ -261,6 +261,8 @@ describe('services/configurations:plugins', () => {
       globals: expectedGlobals,
       resolve: {
         extensions: ['.js', '.json', '.jsx'],
+        browser: false,
+        preferBuiltins: true,
       },
       replace: definitions,
       babel: Object.assign({}, babelConfig, {
@@ -710,6 +712,8 @@ describe('services/configurations:plugins', () => {
       globals: expectedGlobals,
       resolve: {
         extensions: ['.js', '.json', '.jsx'],
+        browser: false,
+        preferBuiltins: true,
       },
       replace: definitions,
       babel: Object.assign({}, babelConfig, {
@@ -1161,6 +1165,8 @@ describe('services/configurations:plugins', () => {
       },
       resolve: {
         extensions: ['.js', '.json', '.jsx'],
+        browser: true,
+        preferBuiltins: false,
       },
       replace: definitions,
       babel: Object.assign({}, babelConfig, {
@@ -1622,6 +1628,8 @@ describe('services/configurations:plugins', () => {
       },
       resolve: {
         extensions: ['.js', '.json', '.jsx'],
+        browser: true,
+        preferBuiltins: false,
       },
       replace: definitions,
       babel: Object.assign({}, babelConfig, {
@@ -2086,6 +2094,8 @@ describe('services/configurations:plugins', () => {
       },
       resolve: {
         extensions: ['.js', '.json', '.jsx'],
+        browser: true,
+        preferBuiltins: false,
       },
       replace: definitions,
       babel: Object.assign({}, babelConfig, {
@@ -2551,6 +2561,8 @@ describe('services/configurations:plugins', () => {
       },
       resolve: {
         extensions: ['.js', '.json', '.jsx'],
+        browser: true,
+        preferBuiltins: false,
       },
       replace: definitions,
       babel: Object.assign({}, babelConfig, {


### PR DESCRIPTION
### What does this PR do?

I added two extra settings for the `resolve` plugin:

- `browser`: Set to `true` when the target is for browser. Allows the plugin to correctly resolve packages that use the `browser` key. [Like `Jimple`](https://github.com/fjorgemota/jimple/blob/master/package.json#L6).
- `preferBuiltins`: Set to `true` when the target is for Node. It shouldn't try to use native Node modules when the target is for browser.

### How should it be tested manually?

For `browser`, you can try building a browser target that imports `Jimple`.

For `preferBuiltins`, you can try building a browser target that imports [`querystring`](https://yarnpkg.com/en/package/querystring).

And of course...

```bash
npm test
# or
yarn test
```
