### PR TITLE
Add multiple overwrite paths for the configurations

### DIFF
--- a/src/services/configurations/browserDevelopmentConfiguration.js
+++ b/src/services/configurations/browserDevelopmentConfiguration.js
@@ -36,7 +36,10 @@ class RollupBrowserDevelopmentConfiguration extends ConfigurationFile {
     pathUtils,
     rollupPluginSettingsConfiguration
   ) {
-    super(pathUtils, 'rollup/browser.development.config.js');
+    super(pathUtils, [
+      'config/rollup/browser.development.config.js',
+      'config/rollup/browser.config.js',
+    ]);
     /**
      * A local reference for the `events` service.
      * @type {Events}

--- a/src/services/configurations/browserProductionConfiguration.js
+++ b/src/services/configurations/browserProductionConfiguration.js
@@ -37,7 +37,10 @@ class RollupBrowserProductionConfiguration extends ConfigurationFile {
     pathUtils,
     rollupPluginSettingsConfiguration
   ) {
-    super(pathUtils, 'rollup/browser.production.config.js');
+    super(pathUtils, [
+      'config/rollup/browser.production.config.js',
+      'config/rollup/browser.config.js',
+    ]);
     /**
      * A local reference for the `events` service.
      * @type {Events}

--- a/src/services/configurations/nodeDevelopmentConfiguration.js
+++ b/src/services/configurations/nodeDevelopmentConfiguration.js
@@ -33,7 +33,10 @@ class RollupNodeDevelopmentConfiguration extends ConfigurationFile {
     pathUtils,
     rollupPluginSettingsConfiguration
   ) {
-    super(pathUtils, 'rollup/node.development.config.js');
+    super(pathUtils, [
+      'config/rollup/node.development.config.js',
+      'config/rollup/node.config.js',
+    ]);
     /**
      * A local reference for the `events` service.
      * @type {Events}

--- a/src/services/configurations/nodeProductionConfiguration.js
+++ b/src/services/configurations/nodeProductionConfiguration.js
@@ -32,7 +32,10 @@ class RollupNodeProductionConfiguration extends ConfigurationFile {
     pathUtils,
     rollupPluginSettingsConfiguration
   ) {
-    super(pathUtils, 'rollup/node.production.config.js');
+    super(pathUtils, [
+      'config/rollup/node.production.config.js',
+      'config/rollup/node.config.js',
+    ]);
     /**
      * A local reference for the `events` service.
      * @type {Events}

--- a/tests/services/configurations/browserDevelopmentConfiguration.test.js
+++ b/tests/services/configurations/browserDevelopmentConfiguration.test.js
@@ -163,7 +163,10 @@ describe('services/configurations:browserDevelopmentConfiguration', () => {
     expect(sut.constructorMock).toHaveBeenCalledTimes(1);
     expect(sut.constructorMock).toHaveBeenCalledWith(
       pathUtils,
-      'rollup/browser.development.config.js'
+      [
+        'config/rollup/browser.development.config.js',
+        'config/rollup/browser.config.js',
+      ]
     );
     expect(sut.events).toBe(events);
     expect(sut.pathUtils).toBe(pathUtils);

--- a/tests/services/configurations/browserProductionConfiguration.test.js
+++ b/tests/services/configurations/browserProductionConfiguration.test.js
@@ -169,7 +169,10 @@ describe('services/configurations:browserProductionConfiguration', () => {
     expect(sut.constructorMock).toHaveBeenCalledTimes(1);
     expect(sut.constructorMock).toHaveBeenCalledWith(
       pathUtils,
-      'rollup/browser.production.config.js'
+      [
+        'config/rollup/browser.production.config.js',
+        'config/rollup/browser.config.js',
+      ]
     );
     expect(sut.events).toBe(events);
     expect(sut.pathUtils).toBe(pathUtils);

--- a/tests/services/configurations/nodeDevelopmentConfiguration.test.js
+++ b/tests/services/configurations/nodeDevelopmentConfiguration.test.js
@@ -149,7 +149,10 @@ describe('services/configurations:nodeDevelopmentConfiguration', () => {
     expect(sut.constructorMock).toHaveBeenCalledTimes(1);
     expect(sut.constructorMock).toHaveBeenCalledWith(
       pathUtils,
-      'rollup/node.development.config.js'
+      [
+        'config/rollup/node.development.config.js',
+        'config/rollup/node.config.js',
+      ]
     );
     expect(sut.events).toBe(events);
     expect(sut.pathUtils).toBe(pathUtils);

--- a/tests/services/configurations/nodeProductionConfiguration.test.js
+++ b/tests/services/configurations/nodeProductionConfiguration.test.js
@@ -143,7 +143,10 @@ describe('services/configurations:nodeProductionConfiguration', () => {
     expect(sut.constructorMock).toHaveBeenCalledTimes(1);
     expect(sut.constructorMock).toHaveBeenCalledWith(
       pathUtils,
-      'rollup/node.production.config.js'
+      [
+        'config/rollup/node.production.config.js',
+        'config/rollup/node.config.js',
+      ]
     );
     expect(sut.events).toBe(events);
     expect(sut.pathUtils).toBe(pathUtils);


### PR DESCRIPTION
### What does this PR do?

As the title says, I added extra overwrite paths for the plugin configuration files:

**Browser development configuration:**

- `config/rollup/browser.development.config.js`
- `config/rollup/browser.config.js` <- new

**Browser production configuration:**

- `config/rollup/browser.production.config.js`
- `config/rollup/browser.config.js` <- new


**Node development configuration:**

- `config/rollup/node.development.config.js`
- `config/rollup/node.config.js` <- new

**Node production configuration:**

- `config/rollup/node.production.config.js`
- `config/rollup/node.config.js` <- new

The way it works is projext will take the list of files that can overwrite the configuration and try to find the first one that exists and use it. So, it won't use all, just the first one it finds.

### How should it be tested manually?

This came up on a project where I was using `whatwg-fetch`, which needs a special Rollup config in order to work, so you can try this:

1. Create a project that uses `whatwg-fetch`.
2. Try to build, you should get a warning.
3. Create `/config/rollup/browser.config.js` and add the following code:

```js
module.exports = (params, currentConfig) => Object.assign({}, currentConfig, {
  moduleContext: {
    [require.resolve('whatwg-fetch')]: 'window',
  },
});
```

Try to build again, it should work.

And of course...

```bash
npm test
# or
yarn test
```
