### PR TITLE
Add Babel External helpers

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,8 @@
       "colors": "1.3.0",
 
       "babel-core": "6.26.3",
-      "babel-preset-env": "1.7.0"
+      "babel-preset-env": "1.7.0",
+      "babel-plugin-external-helpers": "6.22.0"
     },
     "devDependencies": {
       "eslint": "4.19.1",

--- a/src/services/configurations/pluginsConfiguration.js
+++ b/src/services/configurations/pluginsConfiguration.js
@@ -14,7 +14,9 @@ class RollupPluginSettingsConfiguration extends ConfigurationFile {
    * @param {Logger}             appLogger          To send to the plugins that support a logger.
    * @param {BabelConfiguration} babelConfiguration To get the target Babel configuration.
    * @param {BabelHelper}        babelHelper        To disable the `modules` setting of the Babel
-   *                                                env preset for a target, as Rollup requires.
+   *                                                env preset for a target, as Rollup requires,
+   *                                                and include the `external-helpers` plugin, to
+   *                                                optimize the transpilation.
    * @param {Events}             events             To reduce the settings.
    * @param {Object}             packageInfo        To get the dependencies and define them as
    *                                                externals for Node targets.
@@ -309,7 +311,9 @@ class RollupPluginSettingsConfiguration extends ConfigurationFile {
     // Get the target Babel configuration.
     const baseConfiguration = this.babelConfiguration.getConfigForTarget(target);
     // Disable the `modules` feature for the `env` preset.
-    const configuration = this.babelHelper.disableEnvPresetModules(baseConfiguration);
+    let configuration = this.babelHelper.disableEnvPresetModules(baseConfiguration);
+    // Add the `external-helpers` plugin to optimize the transpilation.
+    configuration = this.babelHelper.addPlugin(configuration, 'external-helpers');
     // Define the plugin settings.
     const settings = Object.assign(
       {},

--- a/tests/services/configurations/pluginsConfiguration.test.js
+++ b/tests/services/configurations/pluginsConfiguration.test.js
@@ -187,6 +187,11 @@ describe('services/configurations:plugins', () => {
     };
     const babelHelper = {
       disableEnvPresetModules: jest.fn((config) => Object.assign({}, config, { modules: false })),
+      addPlugin: jest.fn((config, plugin) => Object.assign({}, config, {
+        plugins: {
+          [plugin]: true,
+        },
+      })),
     };
     const events = {
       reduce: jest.fn((eventName, configurationToReduce) => configurationToReduce),
@@ -267,6 +272,9 @@ describe('services/configurations:plugins', () => {
       replace: definitions,
       babel: Object.assign({}, babelConfig, {
         modules: false,
+        plugins: {
+          'external-helpers': true,
+        },
         include: rules.js.files.glob.include,
         exclude: rules.js.files.glob.exclude,
       }),
@@ -640,6 +648,11 @@ describe('services/configurations:plugins', () => {
     };
     const babelHelper = {
       disableEnvPresetModules: jest.fn((config) => Object.assign({}, config, { modules: false })),
+      addPlugin: jest.fn((config, plugin) => Object.assign({}, config, {
+        plugins: {
+          [plugin]: true,
+        },
+      })),
     };
     const events = {
       reduce: jest.fn((eventName, configurationToReduce) => configurationToReduce),
@@ -718,6 +731,9 @@ describe('services/configurations:plugins', () => {
       replace: definitions,
       babel: Object.assign({}, babelConfig, {
         modules: false,
+        plugins: {
+          'external-helpers': true,
+        },
         include: rules.js.files.glob.include,
         exclude: rules.js.files.glob.exclude,
       }),
@@ -1101,6 +1117,11 @@ describe('services/configurations:plugins', () => {
     };
     const babelHelper = {
       disableEnvPresetModules: jest.fn((config) => Object.assign({}, config, { modules: false })),
+      addPlugin: jest.fn((config, plugin) => Object.assign({}, config, {
+        plugins: {
+          [plugin]: true,
+        },
+      })),
     };
     const events = {
       reduce: jest.fn((eventName, configurationToReduce) => configurationToReduce),
@@ -1171,6 +1192,9 @@ describe('services/configurations:plugins', () => {
       replace: definitions,
       babel: Object.assign({}, babelConfig, {
         modules: false,
+        plugins: {
+          'external-helpers': true,
+        },
         include: rules.js.files.glob.include,
         exclude: rules.js.files.glob.exclude,
       }),
@@ -1564,6 +1588,11 @@ describe('services/configurations:plugins', () => {
     };
     const babelHelper = {
       disableEnvPresetModules: jest.fn((config) => Object.assign({}, config, { modules: false })),
+      addPlugin: jest.fn((config, plugin) => Object.assign({}, config, {
+        plugins: {
+          [plugin]: true,
+        },
+      })),
     };
     const events = {
       reduce: jest.fn((eventName, configurationToReduce) => configurationToReduce),
@@ -1634,6 +1663,9 @@ describe('services/configurations:plugins', () => {
       replace: definitions,
       babel: Object.assign({}, babelConfig, {
         modules: false,
+        plugins: {
+          'external-helpers': true,
+        },
         include: rules.js.files.glob.include,
         exclude: rules.js.files.glob.exclude,
       }),
@@ -2030,6 +2062,11 @@ describe('services/configurations:plugins', () => {
     };
     const babelHelper = {
       disableEnvPresetModules: jest.fn((config) => Object.assign({}, config, { modules: false })),
+      addPlugin: jest.fn((config, plugin) => Object.assign({}, config, {
+        plugins: {
+          [plugin]: true,
+        },
+      })),
     };
     const events = {
       reduce: jest.fn((eventName, configurationToReduce) => configurationToReduce),
@@ -2100,6 +2137,9 @@ describe('services/configurations:plugins', () => {
       replace: definitions,
       babel: Object.assign({}, babelConfig, {
         modules: false,
+        plugins: {
+          'external-helpers': true,
+        },
         include: rules.js.files.glob.include,
         exclude: rules.js.files.glob.exclude,
       }),
@@ -2497,6 +2537,11 @@ describe('services/configurations:plugins', () => {
     };
     const babelHelper = {
       disableEnvPresetModules: jest.fn((config) => Object.assign({}, config, { modules: false })),
+      addPlugin: jest.fn((config, plugin) => Object.assign({}, config, {
+        plugins: {
+          [plugin]: true,
+        },
+      })),
     };
     const events = {
       reduce: jest.fn((eventName, configurationToReduce) => configurationToReduce),
@@ -2567,6 +2612,9 @@ describe('services/configurations:plugins', () => {
       replace: definitions,
       babel: Object.assign({}, babelConfig, {
         modules: false,
+        plugins: {
+          'external-helpers': true,
+        },
         include: rules.js.files.glob.include,
         exclude: rules.js.files.glob.exclude,
       }),
@@ -2970,6 +3018,11 @@ describe('services/configurations:plugins', () => {
     };
     const babelHelper = {
       disableEnvPresetModules: jest.fn((config) => Object.assign({}, config, { modules: false })),
+      addPlugin: jest.fn((config, plugin) => Object.assign({}, config, {
+        plugins: {
+          [plugin]: true,
+        },
+      })),
     };
     const events = {
       reduce: jest.fn((eventName, configurationToReduce) => configurationToReduce),
@@ -3178,6 +3231,11 @@ describe('services/configurations:plugins', () => {
     };
     const babelHelper = {
       disableEnvPresetModules: jest.fn((config) => Object.assign({}, config, { modules: false })),
+      addPlugin: jest.fn((config, plugin) => Object.assign({}, config, {
+        plugins: {
+          [plugin]: true,
+        },
+      })),
     };
     const events = {
       reduce: jest.fn((eventName, configurationToReduce) => configurationToReduce),
@@ -3381,6 +3439,11 @@ describe('services/configurations:plugins', () => {
     };
     const babelHelper = {
       disableEnvPresetModules: jest.fn((config) => Object.assign({}, config, { modules: false })),
+      addPlugin: jest.fn((config, plugin) => Object.assign({}, config, {
+        plugins: {
+          [plugin]: true,
+        },
+      })),
     };
     const events = {
       reduce: jest.fn((eventName, configurationToReduce) => configurationToReduce),

--- a/yarn.lock
+++ b/yarn.lock
@@ -508,6 +508,12 @@ babel-plugin-check-es2015-constants@^6.22.0:
   dependencies:
     babel-runtime "^6.22.0"
 
+babel-plugin-external-helpers@6.22.0:
+  version "6.22.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-external-helpers/-/babel-plugin-external-helpers-6.22.0.tgz#2285f48b02bd5dede85175caf8c62e86adccefa1"
+  dependencies:
+    babel-runtime "^6.22.0"
+
 babel-plugin-istanbul@^4.1.6:
   version "4.1.6"
   resolved "https://registry.yarnpkg.com/babel-plugin-istanbul/-/babel-plugin-istanbul-4.1.6.tgz#36c59b2192efce81c5b378321b74175add1c9a45"


### PR DESCRIPTION
### What does this PR do?

Rollup throws a lot of warnings when it detects repeated Babel helpers, and it suggests you to use the [`babel-plugin-external-helpers`](https://yarnpkg.com/en/package/babel-plugin-external-helpers) plugin.

So, this is what the PR does, it includes the plugin on the configuration being sent to the Babel plugin.

### How should it be tested manually?

```bash
npm test
# or
yarn test
```