### PR TITLE
Implement the watch mode

### DIFF
--- a/src/services/building/configuration.js
+++ b/src/services/building/configuration.js
@@ -50,13 +50,14 @@ class RollupConfiguration {
   }
   /**
    * This method generates a complete Rollup configuration for a target.
-   * @param {Target} target    The target information.
-   * @param {string} buildType The intended build type: `production` or `development`.
+   * @param {Target}  target    The target information.
+   * @param {string}  buildType The intended build type: `production` or `development`.
+   * @param {boolean} watch     Whether or not Rollup should use the watch mode.
    * @return {Object}
    * @throws {Error} If there's no base configuration for the target type.
    * @throws {Error} If there's no base configuration for the target type and build type.
    */
-  getConfig(target, buildType) {
+  getConfig(target, buildType, watch) {
     const targetType = target.type;
     if (!this.rollupConfigurations[targetType]) {
       throw new Error(`There's no configuration for the selected target type: ${targetType}`);
@@ -98,6 +99,7 @@ class RollupConfiguration {
       buildType,
       paths,
       copy,
+      watch,
     };
 
     let config = this.targetConfiguration(

--- a/src/services/building/engine.js
+++ b/src/services/building/engine.js
@@ -49,28 +49,35 @@ class RollupBuildEngine {
      * @property {string} run    Whether or not to execute the target. This will be like a fake
      *                           boolean as the CLI doesn't support boolean variables, so its value
      *                           will be either `'true'` or `'false'`.
+     * @property {string} watch  Whether or not to watch the target files. This will be like a fake
+     *                           boolean as the CLI doesn't support boolean variables, so its value
+     *                           will be either `'true'` or `'false'`.
      * @access protected
      * @ignore
      */
     this._envVars = {
-      target: 'PROJEXT_ROLLUP_TARGET',
-      type: 'PROJEXT_ROLLUP_BUILD_TYPE',
-      run: 'PROJEXT_ROLLUP_RUN',
+      target: 'PXTRP_TARGET',
+      type: 'PXTRP_TYPE',
+      run: 'PXTRP_RUN',
+      watch: 'PXTRP_WATCH',
     };
   }
   /**
    * Get the CLI build command to bundle a target.
-   * @param  {Target}  target           The target information.
-   * @param  {string}  buildType        The intended build type: `development` or `production`.
-   * @param  {boolean} [forceRun=false] Force the target to run even if the `runOnDevelopment`
-   *                                    setting is `false`.
+   * @param {Target}  target             The target information.
+   * @param {string}  buildType          The intended build type: `development` or `production`.
+   * @param {boolean} [forceRun=false]   Force the target to run even if the `runOnDevelopment`
+   *                                     setting is `false`.
+   * @param {boolean} [forceWatch=false] Force Rollup to use the watch mode even if the `watch`
+   *                                     setting for the required build type is set to `false`.
    * @return {string}
    */
-  getBuildCommand(target, buildType, forceRun = false) {
+  getBuildCommand(target, buildType, forceRun = false, forceWatch = false) {
     const vars = this._getEnvVarsAsString({
       target: target.name,
       type: buildType,
       run: forceRun,
+      watch: forceWatch,
     });
 
     const config = path.join(
@@ -81,7 +88,7 @@ class RollupBuildEngine {
 
     const optionsList = [];
 
-    if ((buildType === 'development' && target.runOnDevelopment) || forceRun) {
+    if ((buildType === 'development' && target.runOnDevelopment) || forceRun || forceWatch) {
       optionsList.push('--watch');
     }
 
@@ -91,12 +98,13 @@ class RollupBuildEngine {
   }
   /**
    * Get a Rollup configuration for a target.
-   * @param {Target} target    The target configuration.
-   * @param {string} buildType The intended build type: `development` or `production`.
+   * @param {Target}  target    The target configuration.
+   * @param {string}  buildType The intended build type: `development` or `production`.
+   * @param {boolean} watch     Whether or not the Rollup watch mode should be enabled.
    * @return {object}
    */
-  getConfiguration(target, buildType) {
-    return this.rollupConfiguration.getConfig(target, buildType);
+  getConfiguration(target, buildType, watch) {
+    return this.rollupConfiguration.getConfig(target, buildType, watch);
   }
   /**
    * Get a Rollup configuration by reading the environment variables sent by the CLI command
@@ -116,7 +124,9 @@ class RollupBuildEngine {
       target.runOnDevelopment = true;
     }
 
-    return this.getConfiguration(target, type);
+    const watch = vars.watch === 'true' || target.watch[type];
+
+    return this.getConfiguration(target, type, watch);
   }
   /**
    * Given a dictionary with the environment variables purpose and values, this method generates
@@ -126,7 +136,7 @@ class RollupBuildEngine {
    *   target: 'my-target',
    *   type: 'development',
    * });
-   * // will output `PROJEXT_ROLLUP_TARGET=my-target PROJEXT_ROLLUP_BUILD_TYPE=development`
+   * // will output `PXTRP_TARGET=my-target PXTRP_TYPE=development`
    * @param {object} values A dictionary with the purpose(alias) of the variables as keys.
    * @return {string}
    * @access protected

--- a/src/services/configurations/browserDevelopmentConfiguration.js
+++ b/src/services/configurations/browserDevelopmentConfiguration.js
@@ -64,7 +64,12 @@ class RollupBrowserDevelopmentConfiguration extends ConfigurationFile {
    * @return {Object}
    */
   createConfig(params) {
-    const { input, output, target } = params;
+    const {
+      input,
+      output,
+      target,
+      watch,
+    } = params;
     // Create the `stats` plugin instance.
     const statsPlugin = stats({
       path: `${target.paths.build}/`,
@@ -125,6 +130,9 @@ class RollupBrowserDevelopmentConfiguration extends ConfigurationFile {
     if (target.runOnDevelopment) {
       config.watch = pluginSettings.watch;
       config.plugins.push(devServerInstance);
+    } else if (watch) {
+      // If the watch mode is enabled and the target won't run, just add the watch settings.
+      config.watch = pluginSettings.watch;
     }
     // Return the reduced configuration.
     return this.events.reduce(

--- a/src/services/configurations/browserProductionConfiguration.js
+++ b/src/services/configurations/browserProductionConfiguration.js
@@ -65,7 +65,12 @@ class RollupBrowserProductionConfiguration extends ConfigurationFile {
    * @return {Object}
    */
   createConfig(params) {
-    const { target, input, output } = params;
+    const {
+      target,
+      input,
+      output,
+      watch,
+    } = params;
     // Create the `stats` plugin instance.
     const statsPlugin = stats({
       path: `${target.paths.build}/`,
@@ -126,6 +131,10 @@ class RollupBrowserProductionConfiguration extends ConfigurationFile {
       plugins,
       external,
     };
+    // If the watch mode is enabled, add the watch settings.
+    if (watch) {
+      config.watch = pluginSettings.watch;
+    }
     // Return the reduced configuration.
     return this.events.reduce(
       [

--- a/src/services/configurations/nodeDevelopmentConfiguration.js
+++ b/src/services/configurations/nodeDevelopmentConfiguration.js
@@ -61,7 +61,12 @@ class RollupNodeDevelopmentConfiguration extends ConfigurationFile {
    * @return {Object}
    */
   createConfig(params) {
-    const { input, output, target } = params;
+    const {
+      input,
+      output,
+      target,
+      watch,
+    } = params;
     // Create the `stats` plugin instance.
     const statsPlugin = stats({
       path: `${target.paths.build}/`,
@@ -108,6 +113,9 @@ class RollupNodeDevelopmentConfiguration extends ConfigurationFile {
     if (target.runOnDevelopment) {
       config.watch = pluginSettings.watch;
       config.plugins.push(nodeRunner(pluginSettings.nodeRunner));
+    } else if (watch) {
+      // If the watch mode is enabled and the target won't run, just add the watch settings.
+      config.watch = pluginSettings.watch;
     }
     // Return the reduced configuration.
     return this.events.reduce(

--- a/src/services/configurations/nodeProductionConfiguration.js
+++ b/src/services/configurations/nodeProductionConfiguration.js
@@ -60,7 +60,12 @@ class RollupNodeProductionConfiguration extends ConfigurationFile {
    * @return {Object}
    */
   createConfig(params) {
-    const { input, output, target } = params;
+    const {
+      input,
+      output,
+      target,
+      watch,
+    } = params;
     // Create the `stats` plugin instance.
     const statsPlugin = stats({
       path: `${target.paths.build}/`,
@@ -103,6 +108,10 @@ class RollupNodeProductionConfiguration extends ConfigurationFile {
       plugins,
       external,
     };
+    // If the watch mode is enabled, add the watch settings.
+    if (watch) {
+      config.watch = pluginSettings.watch;
+    }
     // Return the reduced configuration.
     return this.events.reduce(
       [

--- a/src/typedef.js
+++ b/src/typedef.js
@@ -540,6 +540,8 @@
  *                                                         {@link TargetExtraFile} with
  *                                                         the information of files that need to
  *                                                         be copied during the bundling process.
+ * @property {boolean}                         watch       Whether or not Rollup should use the
+ *                                                         watch mode.
 
 /**
  * @typedef {Object} RollupPluginInfo

--- a/tests/services/building/configuration.test.js
+++ b/tests/services/building/configuration.test.js
@@ -116,6 +116,7 @@ describe('services/building:configuration', () => {
     };
     const targetConfiguration = jest.fn(() => targetConfig);
     const buildType = 'development';
+    const watch = false;
     const target = {
       type: 'node',
       name: 'target',
@@ -158,7 +159,7 @@ describe('services/building:configuration', () => {
       targetConfiguration,
       rollupConfigurations
     );
-    result = sut.getConfig(target, buildType);
+    result = sut.getConfig(target, buildType, watch);
     // Then
     expect(result).toEqual(config);
     expect(buildVersion.getDefinitionVariable).toHaveBeenCalledTimes(1);
@@ -192,6 +193,7 @@ describe('services/building:configuration', () => {
       },
       paths: target.output[buildType],
       copy: [],
+      watch,
     });
   });
 
@@ -221,6 +223,7 @@ describe('services/building:configuration', () => {
     };
     const targetConfiguration = jest.fn(() => targetConfig);
     const buildType = 'development';
+    const watch = false;
     const target = {
       type: 'node',
       name: 'target',
@@ -264,7 +267,7 @@ describe('services/building:configuration', () => {
       targetConfiguration,
       rollupConfigurations
     );
-    result = sut.getConfig(target, buildType);
+    result = sut.getConfig(target, buildType, watch);
     // Then
     expect(result).toEqual(config);
     expect(buildVersion.getDefinitionVariable).toHaveBeenCalledTimes(1);
@@ -298,6 +301,7 @@ describe('services/building:configuration', () => {
       },
       paths: target.output[buildType],
       copy: filesToCopy,
+      watch,
     });
     expect(targets.getFilesToCopy).toHaveBeenCalledTimes(1);
     expect(targets.getFilesToCopy).toHaveBeenCalledWith(target, buildType);
@@ -331,6 +335,7 @@ describe('services/building:configuration', () => {
     };
     const targetConfiguration = jest.fn(() => targetConfig);
     const buildType = 'development';
+    const watch = true;
     const target = {
       type: 'browser',
       name: 'target',
@@ -373,7 +378,7 @@ describe('services/building:configuration', () => {
       targetConfiguration,
       rollupConfigurations
     );
-    result = sut.getConfig(target, buildType);
+    result = sut.getConfig(target, buildType, watch);
     // Then
     expect(result).toEqual(config);
     expect(buildVersion.getDefinitionVariable).toHaveBeenCalledTimes(1);
@@ -405,6 +410,7 @@ describe('services/building:configuration', () => {
       },
       paths: target.output[buildType],
       copy: filesToCopy,
+      watch,
     });
     expect(targets.getFilesToCopy).toHaveBeenCalledTimes(1);
     expect(targets.getFilesToCopy).toHaveBeenCalledWith(target, buildType);
@@ -440,6 +446,7 @@ describe('services/building:configuration', () => {
     };
     const targetConfiguration = jest.fn(() => targetConfig);
     const buildType = 'development';
+    const watch = true;
     const target = {
       type: 'browser',
       name: 'target',
@@ -482,7 +489,7 @@ describe('services/building:configuration', () => {
       targetConfiguration,
       rollupConfigurations
     );
-    result = sut.getConfig(target, buildType);
+    result = sut.getConfig(target, buildType, watch);
     // Then
     expect(result).toEqual(config);
     expect(buildVersion.getDefinitionVariable).toHaveBeenCalledTimes(1);
@@ -515,6 +522,7 @@ describe('services/building:configuration', () => {
       },
       paths: target.output[buildType],
       copy: filesToCopy,
+      watch,
     });
     expect(targets.getBrowserTargetConfiguration).toHaveBeenCalledTimes(1);
     expect(targets.getBrowserTargetConfiguration).toHaveBeenCalledWith(target);
@@ -547,6 +555,7 @@ describe('services/building:configuration', () => {
     };
     const targetConfiguration = jest.fn(() => targetConfig);
     const buildType = 'development';
+    const watch = true;
     const target = {
       type: 'node',
       name: 'target',
@@ -599,7 +608,7 @@ describe('services/building:configuration', () => {
       targetConfiguration,
       rollupConfigurations
     );
-    result = sut.getConfig(target, buildType);
+    result = sut.getConfig(target, buildType, watch);
     // Then
     expect(result).toEqual(expectedConfig);
     expect(buildVersion.getDefinitionVariable).toHaveBeenCalledTimes(1);
@@ -632,6 +641,7 @@ describe('services/building:configuration', () => {
       },
       paths: target.output[buildType],
       copy: [],
+      watch,
     });
   });
 
@@ -664,6 +674,7 @@ describe('services/building:configuration', () => {
     };
     const targetConfiguration = jest.fn(() => targetConfig);
     const buildType = 'development';
+    const watch = false;
     const target = {
       type: 'browser',
       name: 'some-target',
@@ -720,7 +731,7 @@ describe('services/building:configuration', () => {
       targetConfiguration,
       rollupConfigurations
     );
-    result = sut.getConfig(target, buildType);
+    result = sut.getConfig(target, buildType, watch);
     // Then
     expect(result).toEqual(expectedConfig);
     expect(buildVersion.getDefinitionVariable).toHaveBeenCalledTimes(1);
@@ -753,6 +764,7 @@ describe('services/building:configuration', () => {
       },
       paths: target.output[buildType],
       copy: filesToCopy,
+      watch,
     });
     expect(targets.getFilesToCopy).toHaveBeenCalledTimes(1);
     expect(targets.getFilesToCopy).toHaveBeenCalledWith(target, buildType);
@@ -784,6 +796,7 @@ describe('services/building:configuration', () => {
     };
     const targetConfiguration = jest.fn(() => targetConfig);
     const buildType = 'development';
+    const watch = false;
     const target = {
       type: 'node',
       name: 'some-target',
@@ -840,7 +853,7 @@ describe('services/building:configuration', () => {
       targetConfiguration,
       rollupConfigurations
     );
-    result = sut.getConfig(target, buildType);
+    result = sut.getConfig(target, buildType, watch);
     // Then
     expect(result).toEqual(expectedConfig);
     expect(buildVersion.getDefinitionVariable).toHaveBeenCalledTimes(1);
@@ -873,6 +886,7 @@ describe('services/building:configuration', () => {
       },
       paths: target.output[buildType],
       copy: [],
+      watch,
     });
   });
 

--- a/tests/services/building/engine.test.js
+++ b/tests/services/building/engine.test.js
@@ -61,9 +61,10 @@ describe('services/building:engine', () => {
     );
     result = sut.getBuildCommand(target, buildType);
     // Then
-    expect(result).toMatch(/PROJEXT_ROLLUP_TARGET=(?:[\w0-9-_]*?).*?rollup/);
-    expect(result).toMatch(/PROJEXT_ROLLUP_BUILD_TYPE=(?:\w+).*?rollup/);
-    expect(result).toMatch(/PROJEXT_ROLLUP_RUN=(?:true|false).*?rollup/);
+    expect(result).toMatch(/PXTRP_TARGET=(?:[\w0-9-_]*?).*?rollup/);
+    expect(result).toMatch(/PXTRP_TYPE=(?:\w+).*?rollup/);
+    expect(result).toMatch(/PXTRP_RUN=(?:true|false).*?rollup/);
+    expect(result).toMatch(/PXTRP_WATCH=(?:true|false).*?rollup/);
     expect(result).toMatch(new RegExp(`rollup --config ${expectedConfigPath}`));
   });
 
@@ -97,9 +98,10 @@ describe('services/building:engine', () => {
     );
     result = sut.getBuildCommand(target, buildType);
     // Then
-    expect(result).toMatch(/PROJEXT_ROLLUP_TARGET=(?:[\w0-9-_]*?).*?rollup/);
-    expect(result).toMatch(/PROJEXT_ROLLUP_BUILD_TYPE=(?:\w+).*?rollup/);
-    expect(result).toMatch(/PROJEXT_ROLLUP_RUN=(?:true|false).*?rollup/);
+    expect(result).toMatch(/PXTRP_TARGET=(?:[\w0-9-_]*?).*?rollup/);
+    expect(result).toMatch(/PXTRP_TYPE=(?:\w+).*?rollup/);
+    expect(result).toMatch(/PXTRP_RUN=(?:true|false).*?rollup/);
+    expect(result).toMatch(/PXTRP_WATCH=(?:true|false).*?rollup/);
     expect(result).toMatch(new RegExp(`rollup --config ${expectedConfigPath}`));
     expect(result).toMatch(/rollup --config.*?--watch/);
   });
@@ -132,9 +134,10 @@ describe('services/building:engine', () => {
     );
     result = sut.getBuildCommand(target, buildType, true);
     // Then
-    expect(result).toMatch(/PROJEXT_ROLLUP_TARGET=(?:[\w0-9-_]*?).*?rollup/);
-    expect(result).toMatch(/PROJEXT_ROLLUP_BUILD_TYPE=(?:\w+).*?rollup/);
-    expect(result).toMatch(/PROJEXT_ROLLUP_RUN=(?:true|false).*?rollup/);
+    expect(result).toMatch(/PXTRP_TARGET=(?:[\w0-9-_]*?).*?rollup/);
+    expect(result).toMatch(/PXTRP_TYPE=(?:\w+).*?rollup/);
+    expect(result).toMatch(/PXTRP_RUN=(?:true|false).*?rollup/);
+    expect(result).toMatch(/PXTRP_WATCH=(?:true|false).*?rollup/);
     expect(result).toMatch(/rollup --config ([\w_\-/]*?)rollup\.config\.js/);
     expect(result).toMatch(/rollup --config.*?--watch/);
   });
@@ -145,6 +148,7 @@ describe('services/building:engine', () => {
     const targets = 'targets';
     const target = 'some-target';
     const buildType = 'production';
+    const watch = false;
     const config = 'config';
     const rollupConfiguration = {
       getConfig: jest.fn(() => config),
@@ -162,11 +166,11 @@ describe('services/building:engine', () => {
       rollupConfiguration,
       rollupPluginInfo
     );
-    result = sut.getConfiguration(target, buildType);
+    result = sut.getConfiguration(target, buildType, watch);
     // Then
     expect(result).toBe(config);
     expect(rollupConfiguration.getConfig).toHaveBeenCalledTimes(1);
-    expect(rollupConfiguration.getConfig).toHaveBeenCalledWith(target, buildType);
+    expect(rollupConfiguration.getConfig).toHaveBeenCalledWith(target, buildType, watch);
   });
 
   it('should return a target Rollup configuration', () => {
@@ -174,13 +178,18 @@ describe('services/building:engine', () => {
     const targetName = 'some-target';
     const buildType = 'development';
     const run = false;
+    const watch = false;
     const target = {
       name: targetName,
+      watch: {
+        [buildType]: watch,
+      },
     };
     const envVars = {
-      PROJEXT_ROLLUP_TARGET: targetName,
-      PROJEXT_ROLLUP_BUILD_TYPE: buildType,
-      PROJEXT_ROLLUP_RUN: run.toString(),
+      PXTRP_TARGET: targetName,
+      PXTRP_TYPE: buildType,
+      PXTRP_RUN: run.toString(),
+      PXTRP_WATCH: watch.toString(),
     };
     const envVarsNames = Object.keys(envVars);
     const environmentUtils = {
@@ -210,7 +219,7 @@ describe('services/building:engine', () => {
     // Then
     expect(result).toBe(config);
     expect(rollupConfiguration.getConfig).toHaveBeenCalledTimes(1);
-    expect(rollupConfiguration.getConfig).toHaveBeenCalledWith(target, buildType);
+    expect(rollupConfiguration.getConfig).toHaveBeenCalledWith(target, buildType, watch);
     expect(targets.getTarget).toHaveBeenCalledTimes(1);
     expect(targets.getTarget).toHaveBeenCalledWith(targetName);
     expect(environmentUtils.get).toHaveBeenCalledTimes(envVarsNames.length);
@@ -224,13 +233,18 @@ describe('services/building:engine', () => {
     const targetName = 'some-target';
     const buildType = 'development';
     const run = true;
+    const watch = true;
     const target = {
       name: targetName,
+      watch: {
+        [buildType]: watch,
+      },
     };
     const envVars = {
-      PROJEXT_ROLLUP_TARGET: targetName,
-      PROJEXT_ROLLUP_BUILD_TYPE: buildType,
-      PROJEXT_ROLLUP_RUN: run.toString(),
+      PXTRP_TARGET: targetName,
+      PXTRP_TYPE: buildType,
+      PXTRP_RUN: run.toString(),
+      PXTRP_WATCH: watch.toString(),
     };
     const envVarsNames = Object.keys(envVars);
     const environmentUtils = {
@@ -260,13 +274,17 @@ describe('services/building:engine', () => {
     // Then
     expect(result).toBe(config);
     expect(rollupConfiguration.getConfig).toHaveBeenCalledTimes(1);
-    expect(rollupConfiguration.getConfig).toHaveBeenCalledWith(Object.assign(
-      {},
-      target,
-      {
-        runOnDevelopment: true,
-      }
-    ), buildType);
+    expect(rollupConfiguration.getConfig).toHaveBeenCalledWith(
+      Object.assign(
+        {},
+        target,
+        {
+          runOnDevelopment: true,
+        }
+      ),
+      buildType,
+      watch
+    );
     expect(targets.getTarget).toHaveBeenCalledTimes(1);
     expect(targets.getTarget).toHaveBeenCalledWith(targetName);
     expect(environmentUtils.get).toHaveBeenCalledTimes(envVarsNames.length);
@@ -278,9 +296,10 @@ describe('services/building:engine', () => {
   it('should throw an error when getting a configuration without the env variables', () => {
     // Given
     const envVarsNames = [
-      'PROJEXT_ROLLUP_TARGET',
-      'PROJEXT_ROLLUP_BUILD_TYPE',
-      'PROJEXT_ROLLUP_RUN',
+      'PXTRP_TARGET',
+      'PXTRP_TYPE',
+      'PXTRP_RUN',
+      'PXTRP_WATCH',
     ];
     const environmentUtils = {
       get: jest.fn(),

--- a/tests/services/configurations/browserDevelopmentConfiguration.test.js
+++ b/tests/services/configurations/browserDevelopmentConfiguration.test.js
@@ -211,10 +211,12 @@ describe('services/configurations:browserDevelopmentConfiguration', () => {
     };
     const output = {};
     const input = 'input';
+    const watch = false;
     const params = {
       target,
       input,
       output,
+      watch,
     };
     let sut = null;
     let result = null;
@@ -314,10 +316,12 @@ describe('services/configurations:browserDevelopmentConfiguration', () => {
     };
     const output = {};
     const input = 'input';
+    const watch = false;
     const params = {
       target,
       input,
       output,
+      watch,
     };
     let sut = null;
     let result = null;
@@ -383,10 +387,12 @@ describe('services/configurations:browserDevelopmentConfiguration', () => {
       },
     };
     const input = 'input';
+    const watch = false;
     const params = {
       target,
       input,
       output,
+      watch,
     };
     let sut = null;
     let result = null;
@@ -446,10 +452,12 @@ describe('services/configurations:browserDevelopmentConfiguration', () => {
     };
     const output = {};
     const input = 'input';
+    const watch = false;
     const params = {
       target,
       input,
       output,
+      watch,
     };
     let sut = null;
     let result = null;
@@ -499,6 +507,72 @@ describe('services/configurations:browserDevelopmentConfiguration', () => {
       },
       plugins.settings.statsLog
     ));
+  });
+
+  it('should create a configuration for a target that will be watched', () => {
+    // Given
+    const plugins = getPlugins();
+    const events = {
+      reduce: jest.fn((eventNames, config) => config),
+    };
+    const pathUtils = 'pathUtils';
+    const rollupPluginSettingsConfiguration = {
+      getConfig: jest.fn(() => plugins.settings),
+    };
+    const target = {
+      css: {
+        modules: true,
+      },
+      paths: {
+        build: 'dist',
+      },
+      runOnDevelopment: false,
+    };
+    const output = {};
+    const input = 'input';
+    const watch = true;
+    const params = {
+      target,
+      input,
+      output,
+      watch,
+    };
+    let sut = null;
+    let result = null;
+    // When
+    sut = new RollupBrowserDevelopmentConfiguration(
+      events,
+      pathUtils,
+      rollupPluginSettingsConfiguration
+    );
+    result = sut.getConfig(params);
+    // Then
+    expect(result).toEqual({
+      input,
+      output: Object.assign({}, output, {
+        globals: plugins.settings.globals,
+      }),
+      plugins: [
+        plugins.values.statsReset,
+        plugins.values.resolve,
+        plugins.values.commonjs,
+        plugins.values.babel,
+        plugins.values.windowAsGlobal,
+        plugins.values.replace,
+        plugins.values.sass,
+        plugins.values.css,
+        plugins.values.stylesheetAssets,
+        plugins.values.stylesheetModulesFixer,
+        plugins.values.html,
+        plugins.values.json,
+        plugins.values.urls,
+        plugins.values.template,
+        plugins.values.copy,
+        plugins.values.statsLog,
+      ],
+      watch: plugins.settings.watch,
+      external: plugins.settings.external.external,
+    });
   });
 
   it('should include a provider for the DIC', () => {

--- a/tests/services/configurations/browserProductionConfiguration.test.js
+++ b/tests/services/configurations/browserProductionConfiguration.test.js
@@ -203,10 +203,12 @@ describe('services/configurations:browserProductionConfiguration', () => {
     };
     const output = {};
     const input = 'input';
+    const watch = false;
     const params = {
       target,
       input,
       output,
+      watch,
     };
     let sut = null;
     let result = null;
@@ -290,6 +292,77 @@ describe('services/configurations:browserProductionConfiguration', () => {
     );
   });
 
+  it('should create a configuration for a target that will be watched', () => {
+    // Given
+    const plugins = getPlugins();
+    const events = {
+      reduce: jest.fn((eventNames, config) => config),
+    };
+    const pathUtils = 'pathUtils';
+    const rollupPluginSettingsConfiguration = {
+      getConfig: jest.fn(() => plugins.settings),
+    };
+    const target = {
+      css: {
+        modules: true,
+      },
+      paths: {
+        build: 'dist',
+      },
+    };
+    const output = {
+      globals: {
+        wootils: 'wootils',
+      },
+    };
+    const input = 'input';
+    const watch = true;
+    const params = {
+      target,
+      input,
+      output,
+      watch,
+    };
+    let sut = null;
+    let result = null;
+    // When
+    sut = new RollupBrowserProductionConfiguration(
+      events,
+      pathUtils,
+      rollupPluginSettingsConfiguration
+    );
+    result = sut.getConfig(params);
+    // Then
+    expect(result).toEqual({
+      input,
+      output: Object.assign({}, output, {
+        globals: Object.assign({}, output.globals, plugins.settings.globals),
+      }),
+      plugins: [
+        plugins.values.statsReset,
+        plugins.values.resolve,
+        plugins.values.commonjs,
+        plugins.values.babel,
+        plugins.values.windowAsGlobal,
+        plugins.values.replace,
+        plugins.values.sass,
+        plugins.values.css,
+        plugins.values.stylesheetAssets,
+        plugins.values.stylesheetModulesFixer,
+        plugins.values.html,
+        plugins.values.json,
+        plugins.values.urls,
+        plugins.values.uglify,
+        plugins.values.copy,
+        plugins.values.template,
+        plugins.values.compression,
+        plugins.values.statsLog,
+      ],
+      watch: plugins.settings.watch,
+      external: plugins.settings.external.external,
+    });
+  });
+
   it('should create a configuration for a target with CSS modules', () => {
     // Given
     const plugins = getPlugins();
@@ -310,10 +383,12 @@ describe('services/configurations:browserProductionConfiguration', () => {
     };
     const output = {};
     const input = 'input';
+    const watch = false;
     const params = {
       target,
       input,
       output,
+      watch,
     };
     let sut = null;
     let result = null;
@@ -381,10 +456,12 @@ describe('services/configurations:browserProductionConfiguration', () => {
       },
     };
     const input = 'input';
+    const watch = false;
     const params = {
       target,
       input,
       output,
+      watch,
     };
     let sut = null;
     let result = null;
@@ -445,10 +522,12 @@ describe('services/configurations:browserProductionConfiguration', () => {
     };
     const output = {};
     const input = 'input';
+    const watch = false;
     const params = {
       target,
       input,
       output,
+      watch,
     };
     let sut = null;
     let result = null;
@@ -512,10 +591,12 @@ describe('services/configurations:browserProductionConfiguration', () => {
     };
     const output = {};
     const input = 'input';
+    const watch = false;
     const params = {
       target,
       input,
       output,
+      watch,
     };
     let sut = null;
     let result = null;

--- a/tests/services/configurations/nodeDevelopmentConfiguration.test.js
+++ b/tests/services/configurations/nodeDevelopmentConfiguration.test.js
@@ -183,10 +183,12 @@ describe('services/configurations:nodeDevelopmentConfiguration', () => {
     };
     const output = {};
     const input = 'input';
+    const watch = false;
     const params = {
       target,
       input,
       output,
+      watch,
     };
     let sut = null;
     let result = null;
@@ -287,10 +289,12 @@ describe('services/configurations:nodeDevelopmentConfiguration', () => {
       },
     };
     const input = 'input';
+    const watch = false;
     const params = {
       target,
       input,
       output,
+      watch,
     };
     let sut = null;
     let result = null;
@@ -346,10 +350,12 @@ describe('services/configurations:nodeDevelopmentConfiguration', () => {
     };
     const output = {};
     const input = 'input';
+    const watch = false;
     const params = {
       target,
       input,
       output,
+      watch,
     };
     let sut = null;
     let result = null;
@@ -388,6 +394,68 @@ describe('services/configurations:nodeDevelopmentConfiguration', () => {
     });
     expect(plugins.mocks.nodeRunner).toHaveBeenCalledTimes(1);
     expect(plugins.mocks.nodeRunner).toHaveBeenCalledWith(plugins.settings.nodeRunner);
+  });
+
+  it('should create a configuration for a target that will be watched', () => {
+    // Given
+    const plugins = getPlugins();
+    const events = {
+      reduce: jest.fn((eventNames, config) => config),
+    };
+    const pathUtils = 'pathUtils';
+    const rollupPluginSettingsConfiguration = {
+      getConfig: jest.fn(() => plugins.settings),
+    };
+    const target = {
+      css: {},
+      paths: {
+        build: 'dist',
+      },
+      runOnDevelopment: false,
+    };
+    const output = {};
+    const input = 'input';
+    const watch = true;
+    const params = {
+      target,
+      input,
+      output,
+      watch,
+    };
+    let sut = null;
+    let result = null;
+    // When
+    sut = new RollupNodeDevelopmentConfiguration(
+      events,
+      pathUtils,
+      rollupPluginSettingsConfiguration
+    );
+    result = sut.getConfig(params);
+    // Then
+    expect(result).toEqual({
+      input,
+      output: Object.assign({}, output, {
+        globals: plugins.settings.globals,
+      }),
+      plugins: [
+        plugins.values.statsReset,
+        plugins.values.resolve,
+        plugins.values.commonjs,
+        plugins.values.babel,
+        plugins.values.replace,
+        plugins.values.sass,
+        plugins.values.css,
+        plugins.values.stylesheetAssetsHelper,
+        plugins.values.stylesheetAssets,
+        plugins.values.html,
+        plugins.values.json,
+        plugins.values.urls,
+        plugins.values.copy,
+        plugins.values.statsLog,
+      ],
+      external: plugins.settings.external.external,
+      watch: plugins.settings.watch,
+    });
   });
 
   it('should include a provider for the DIC', () => {

--- a/tests/services/configurations/nodeProductionConfiguration.test.js
+++ b/tests/services/configurations/nodeProductionConfiguration.test.js
@@ -177,10 +177,12 @@ describe('services/configurations:nodeProductionConfiguration', () => {
     };
     const output = {};
     const input = 'input';
+    const watch = false;
     const params = {
       target,
       input,
       output,
+      watch,
     };
     let sut = null;
     let result = null;
@@ -281,10 +283,12 @@ describe('services/configurations:nodeProductionConfiguration', () => {
       },
     };
     const input = 'input';
+    const watch = false;
     const params = {
       target,
       input,
       output,
+      watch,
     };
     let sut = null;
     let result = null;
@@ -318,6 +322,67 @@ describe('services/configurations:nodeProductionConfiguration', () => {
         plugins.values.statsLog,
       ],
       external: plugins.settings.external.external,
+    });
+  });
+
+  it('should create a configuration for a target that will be watched', () => {
+    // Given
+    const plugins = getPlugins();
+    const events = {
+      reduce: jest.fn((eventNames, config) => config),
+    };
+    const pathUtils = 'pathUtils';
+    const rollupPluginSettingsConfiguration = {
+      getConfig: jest.fn(() => plugins.settings),
+    };
+    const target = {
+      css: {},
+      paths: {
+        build: 'dist',
+      },
+    };
+    const output = {};
+    const input = 'input';
+    const watch = true;
+    const params = {
+      target,
+      input,
+      output,
+      watch,
+    };
+    let sut = null;
+    let result = null;
+    // When
+    sut = new RollupNodeProductionConfiguration(
+      events,
+      pathUtils,
+      rollupPluginSettingsConfiguration
+    );
+    result = sut.getConfig(params);
+    // Then
+    expect(result).toEqual({
+      input,
+      output: Object.assign({}, output, {
+        globals: plugins.settings.globals,
+      }),
+      plugins: [
+        plugins.values.statsReset,
+        plugins.values.resolve,
+        plugins.values.commonjs,
+        plugins.values.babel,
+        plugins.values.replace,
+        plugins.values.sass,
+        plugins.values.css,
+        plugins.values.stylesheetAssetsHelper,
+        plugins.values.stylesheetAssets,
+        plugins.values.html,
+        plugins.values.json,
+        plugins.values.urls,
+        plugins.values.copy,
+        plugins.values.statsLog,
+      ],
+      external: plugins.settings.external.external,
+      watch: plugins.settings.watch,
     });
   });
 


### PR DESCRIPTION
### What does this PR do?

On homer0/projext#53 I added support for a watch mode, this PR is the implementation on Rollup (plus a minor refactor of the **private** environment variables names).

Since the projext PR is breaking and this one needs that version, this will also be a breaking change.

### How should it be tested manually?

You first need `projext#next` installed, then try using the new `projext watch` command for a bundled target.

And of course...

```bash
npm test
# or
yarn test
```
