### PR TITLE
Implement uglifyOnProduction

### DIFF
--- a/src/services/configurations/browserProductionConfiguration.js
+++ b/src/services/configurations/browserProductionConfiguration.js
@@ -99,7 +99,11 @@ class RollupBrowserProductionConfiguration extends ConfigurationFile {
       html(pluginSettings.html),
       json(pluginSettings.json),
       urls(pluginSettings.urls),
-      uglify(pluginSettings.uglify),
+      ...(
+        target.uglifyOnProduction ?
+          [uglify(pluginSettings.uglify)] :
+          []
+      ),
       copy(pluginSettings.copy),
     ];
     // If the target is not a library, push the template plugin for the HTML file.

--- a/tests/services/configurations/browserProductionConfiguration.test.js
+++ b/tests/services/configurations/browserProductionConfiguration.test.js
@@ -200,6 +200,7 @@ describe('services/configurations:browserProductionConfiguration', () => {
       paths: {
         build: 'dist',
       },
+      uglifyOnProduction: true,
     };
     const output = {};
     const input = 'input';
@@ -309,6 +310,7 @@ describe('services/configurations:browserProductionConfiguration', () => {
       paths: {
         build: 'dist',
       },
+      uglifyOnProduction: true,
     };
     const output = {
       globals: {
@@ -363,6 +365,77 @@ describe('services/configurations:browserProductionConfiguration', () => {
     });
   });
 
+  it('should create a configuration with the uglifier disabled', () => {
+    // Given
+    const plugins = getPlugins();
+    const events = {
+      reduce: jest.fn((eventNames, config) => config),
+    };
+    const pathUtils = 'pathUtils';
+    const rollupPluginSettingsConfiguration = {
+      getConfig: jest.fn(() => plugins.settings),
+    };
+    const target = {
+      css: {
+        modules: true,
+      },
+      paths: {
+        build: 'dist',
+      },
+      uglifyOnProduction: false,
+    };
+    const output = {
+      globals: {
+        wootils: 'wootils',
+      },
+    };
+    const input = 'input';
+    const watch = true;
+    const params = {
+      target,
+      input,
+      output,
+      watch,
+    };
+    let sut = null;
+    let result = null;
+    // When
+    sut = new RollupBrowserProductionConfiguration(
+      events,
+      pathUtils,
+      rollupPluginSettingsConfiguration
+    );
+    result = sut.getConfig(params);
+    // Then
+    expect(result).toEqual({
+      input,
+      output: Object.assign({}, output, {
+        globals: Object.assign({}, output.globals, plugins.settings.globals),
+      }),
+      plugins: [
+        plugins.values.statsReset,
+        plugins.values.resolve,
+        plugins.values.commonjs,
+        plugins.values.babel,
+        plugins.values.windowAsGlobal,
+        plugins.values.replace,
+        plugins.values.sass,
+        plugins.values.css,
+        plugins.values.stylesheetAssets,
+        plugins.values.stylesheetModulesFixer,
+        plugins.values.html,
+        plugins.values.json,
+        plugins.values.urls,
+        plugins.values.copy,
+        plugins.values.template,
+        plugins.values.compression,
+        plugins.values.statsLog,
+      ],
+      watch: plugins.settings.watch,
+      external: plugins.settings.external.external,
+    });
+  });
+
   it('should create a configuration for a target with CSS modules', () => {
     // Given
     const plugins = getPlugins();
@@ -380,6 +453,7 @@ describe('services/configurations:browserProductionConfiguration', () => {
       paths: {
         build: 'dist',
       },
+      uglifyOnProduction: true,
     };
     const output = {};
     const input = 'input';
@@ -449,6 +523,7 @@ describe('services/configurations:browserProductionConfiguration', () => {
       paths: {
         build: 'dist',
       },
+      uglifyOnProduction: true,
     };
     const output = {
       globals: {
@@ -519,6 +594,7 @@ describe('services/configurations:browserProductionConfiguration', () => {
       paths: {
         build: 'dist',
       },
+      uglifyOnProduction: true,
     };
     const output = {};
     const input = 'input';
@@ -588,6 +664,7 @@ describe('services/configurations:browserProductionConfiguration', () => {
       libraryOptions: {
         compress: true,
       },
+      uglifyOnProduction: true,
     };
     const output = {};
     const input = 'input';


### PR DESCRIPTION
### What does this PR do?

On homer0/projext#54 (and homer0/projext#55 😞 ) I added a new browser target setting: `uglifyOnProduction` with the default value of `true`. If you turn the setting off, your productions build won't be uglyfied anymore.

This can be helpful for debugging production code.

### How should it be tested manually?

Turn the flag off and generate a new build.

And of course...

```bash
yarn test
# or
npm test
```
