### PR TITLE
Avoid using postcss when is not necessary

### DIFF
--- a/src/services/configurations/pluginsConfiguration.js
+++ b/src/services/configurations/pluginsConfiguration.js
@@ -1215,9 +1215,19 @@ class RollupPluginSettingsConfiguration extends ConfigurationFile {
         }));
       }
 
-      return postcss(plugins)
-      // Process the stylesheet code.
-      .process(css, options)
+      let processor;
+      // Avoid using `postcss` if not needed
+      if (plugins.length || options.map || options.from) {
+        processor = postcss(plugins)
+        // Process the stylesheet code.
+        .process(css, options);
+      } else {
+        processor = Promise.resolve({
+          css: css.replace(map, '').trim(),
+        });
+      }
+
+      return processor
       .then((processed) => {
         // Add the source map if needed.
         const cssCode = options.map ?

--- a/tests/services/configurations/pluginsConfiguration.test.js
+++ b/tests/services/configurations/pluginsConfiguration.test.js
@@ -2978,11 +2978,6 @@ describe('services/configurations:plugins', () => {
 
   it('should generate the settings for processing SASS', () => {
     // Given
-    postcss.mockImplementationOnce(() => ({
-      process: jest.fn((css) => Promise.resolve({
-        css: css.split('/').shift().trim(),
-      })),
-    }));
     const postcssModulesName = 'postcss-modules-plugin';
     postcssModules.mockImplementationOnce(() => postcssModulesName);
     const buildType = 'development';
@@ -3175,8 +3170,7 @@ describe('services/configurations:plugins', () => {
     .then((processed) => {
       expect(processed).toBe(`${cssCode}\n\n${cssMapStr}\n`);
       expect(postcssModules).toHaveBeenCalledTimes(0);
-      expect(postcss).toHaveBeenCalledTimes(1);
-      expect(postcss).toHaveBeenCalledWith([]);
+      expect(postcss).toHaveBeenCalledTimes(0);
     })
     .catch(() => {
       expect(true).toBeFalse();


### PR DESCRIPTION
### What does this PR do?

As the title says, this change will prevent the plugin from using `postcss` when it doesn't need it, thus avoiding the this warning:

> You did not set any plugins, parser, or stringifier. Right now PostCSS do nothing. Pick plugins for your case on https://www.postcss.parts/ and use them in postcss.config.js.

### How should it be tested manually?

This is a non breaking change, so everything should keep working as it was; and of course...

```bash
npm test
# or
yarn test
```
