### PR TITLE
v2.0.1: Fix URL the browser opens when the Dev Server is being proxied

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "projext-plugin-rollup",
     "description": "Allows projext to use Rollup as a build engine.",
     "homepage": "https://homer0.github.io/projext-plugin-rollup/",
-    "version": "2.0.0",
+    "version": "2.0.1",
     "repository": "homer0/projext-plugin-rollup",
     "author": "Leonardo Apiwan (@homer0) <me@homer0.com>",
     "license": "MIT",

--- a/src/plugins/devServer/index.js
+++ b/src/plugins/devServer/index.js
@@ -42,6 +42,7 @@ class ProjextRollupDevServerPlugin {
         https: null,
         open: true,
         logger: null,
+        proxied: null,
         onStart: () => {},
         onStop: () => {},
       },
@@ -175,8 +176,27 @@ class ProjextRollupDevServerPlugin {
    * @ignore
    */
   _createServerURL() {
-    const protocol = this._options.https ? 'https' : 'http';
-    return `${protocol}://${this._options.host}:${this._options.port}`;
+    let url;
+    const {
+      https: useHTTPS,
+      host,
+      port,
+      proxied,
+    } = this._options;
+    /**
+     * If the server is being proxied and the host is different form the one on the base config,
+     * build the URL using the _"proxied settings"_.
+     */
+    if (proxied && proxied.host !== host) {
+      const proxiedProtocol = proxied.https ? 'https' : 'http';
+      url = `${proxiedProtocol}://${proxied.host}`;
+    } else {
+      // ...otherwise, use the base config.
+      const protocol = useHTTPS ? 'https' : 'http';
+      url = `${protocol}://${host}:${port}`;
+    }
+
+    return url;
   }
   /**
    * Normalizes the `contentBase` option into an array.

--- a/src/services/configurations/pluginsConfiguration.js
+++ b/src/services/configurations/pluginsConfiguration.js
@@ -851,6 +851,33 @@ class RollupPluginSettingsConfiguration extends ConfigurationFile {
     if (atLeastOneSSLSetting) {
       settings.https = sslSettings;
     }
+    /**
+     * Build the _"proxied settings"_ in case the server is behind a proxy. This will tell the
+     * dev server plugin to build a URL using these settings and use it for opening the browser
+     * and logging messages, instead of the base one.
+     */
+    if (devServer.proxied.enabled) {
+      /**
+       * Define the proxied host by checking if one was defined on the settings. If there's no
+       * host, it will fallback to the one on the base settings.
+       */
+      const proxiedHost = devServer.proxied.host === null ?
+        settings.host :
+        devServer.proxied.host;
+      /**
+       * Define whether to use HTTPS by checking the settings. If it wasn't specified, it will
+       * only set it to `true` if one of the SSL files for the base config exists.
+       */
+      const proxiedHTTPS = devServer.proxied.https === null ?
+        atLeastOneSSLSetting :
+        devServer.proxied.https;
+      // Add the `proxied` settings to the object to be returned.
+      settings.proxied = {
+        host: proxiedHost,
+        https: proxiedHTTPS,
+      };
+    }
+
     // Return the reduced configuration.
     return this.events.reduce(
       'rollup-dev-server-plugin-settings-configuration',

--- a/src/typedef.js
+++ b/src/typedef.js
@@ -264,29 +264,36 @@
 
 /**
  * @typedef {Object} ProjextRollupDevServerPluginOptions
- * @property {string}                            host               The server hostname.
- * @property {number}                            port               The server port.
- * @property {Array|string}                      contentBase        The directory from where the
- *                                                                  files are going to be served.
- *                                                                  It can be a single directory
- *                                                                  or a list of them.
- * @property {boolean}                           historyApiFallback Whether or not the server
- *                                                                  should redirect the user to
- *                                                                  the `index.html` after a
- *                                                                  `404`.
- * @property {null|HTTPSOptions}                 https              The required files to run the
- *                                                                  server on HTTPs. They are the
- *                                                                  same that `https.createServer`
- *                                                                  supports.
- * @property {boolean}                           open               Whether or not the browser
- *                                                                  should be opened after
- *                                                                  starting the server.
- * @property {?Logger}                           logger             A custom logger to log the
- *                                                                  server events.
- * @property {ProjextRollupDevServerPluginEvent} onStart            A callback to be called when
- *                                                                  the server starts.
- * @property {ProjextRollupDevServerPluginEvent} onStop             A callback to be called when
- *                                                                  the server stops.
+ * @property {string} host
+ * The host used to proxy the dev server.
+ * @property {boolean} https
+ * Whether or not the proxied host uses `https`.
+ */
+
+/**
+ * @typedef {Object} ProjextRollupDevServerPluginOptions
+ * @property {string} host
+ * The server hostname.
+ * @property {number} port
+ * The server port.
+ * @property {Array|string} contentBase
+ * The directory from where the files are going to be served. It can be a single directory or a
+ * list of them.
+ * @property {boolean} historyApiFallback
+ * Whether or not the server should redirect the user to the `index.html` after a `404`.
+ * @property {null|HTTPSOptions} https
+ * The required files to run the server on HTTPs. They are the same that `https.createServer`
+ * supports.
+ * @property {boolean} open
+ * Whether or not the browser should be opened after starting the server.
+ * @property {?Logger} logger
+ * A custom logger to log the server events.
+ * @property {?ProjextRollupDevServerPluginProxiedSettings} proxied
+ * The settings in case the server is being proxied.
+ * @property {ProjextRollupDevServerPluginEvent} onStart
+ * A callback to be called when the server starts.
+ * @property {ProjextRollupDevServerPluginEvent} onStop
+ * A callback to be called when the server stops.
  */
 
 /**

--- a/tests/plugins/devServer/index.test.js
+++ b/tests/plugins/devServer/index.test.js
@@ -63,6 +63,7 @@ describe('plugins:devServer', () => {
       https: null,
       open: true,
       logger: null,
+      proxied: null,
       onStart: expect.any(Function),
       onStop: expect.any(Function),
     });
@@ -86,6 +87,10 @@ describe('plugins:devServer', () => {
       },
       open: false,
       logger: 'logger',
+      proxied: {
+        enabled: true,
+        host: 'my-host',
+      },
       onStart: jest.fn(),
       onStop: jest.fn(),
     };
@@ -98,6 +103,68 @@ describe('plugins:devServer', () => {
     // Then
     expect(sut).toBeInstanceOf(ProjextRollupDevServerPlugin);
     expect(sut.name).toBe(name);
+    expect(sut.url).toBe(`https://${options.host}:${options.port}`);
+    expect(result).toEqual(options);
+  });
+
+  it('should be instantiated with a custom proxied host', () => {
+    // Given
+    const options = {
+      host: 'my-host',
+      port: 2509,
+      contentBase: ['/'],
+      historyApiFallback: true,
+      https: null,
+      open: false,
+      logger: 'logger',
+      proxied: {
+        enabled: true,
+        host: 'my-proxied-host',
+      },
+      onStart: jest.fn(),
+      onStop: jest.fn(),
+    };
+    const name = 'my-dev-server-plugin';
+    let sut = null;
+    let result = null;
+    // When
+    sut = new ProjextRollupDevServerPlugin(options, name);
+    result = sut.getOptions();
+    // Then
+    expect(sut).toBeInstanceOf(ProjextRollupDevServerPlugin);
+    expect(sut.name).toBe(name);
+    expect(sut.url).toBe(`http://${options.proxied.host}`);
+    expect(result).toEqual(options);
+  });
+
+  it('should be instantiated with a custom SSL proxied host', () => {
+    // Given
+    const options = {
+      host: 'my-host',
+      port: 2509,
+      contentBase: ['/'],
+      historyApiFallback: true,
+      https: null,
+      open: false,
+      logger: 'logger',
+      proxied: {
+        enabled: true,
+        host: 'my-proxied-host',
+        https: true,
+      },
+      onStart: jest.fn(),
+      onStop: jest.fn(),
+    };
+    const name = 'my-dev-server-plugin';
+    let sut = null;
+    let result = null;
+    // When
+    sut = new ProjextRollupDevServerPlugin(options, name);
+    result = sut.getOptions();
+    // Then
+    expect(sut).toBeInstanceOf(ProjextRollupDevServerPlugin);
+    expect(sut.name).toBe(name);
+    expect(sut.url).toBe(`https://${options.proxied.host}`);
     expect(result).toEqual(options);
   });
 

--- a/tests/services/configurations/pluginsConfiguration.test.js
+++ b/tests/services/configurations/pluginsConfiguration.test.js
@@ -1052,6 +1052,7 @@ describe('services/configurations:plugins', () => {
         host: 'localhost',
         port: 2509,
         ssl: {},
+        proxied: {},
       },
       excludeModules: [
         excludeModule,
@@ -1539,6 +1540,7 @@ describe('services/configurations:plugins', () => {
         host: 'localhost',
         port: 2509,
         ssl: {},
+        proxied: {},
       },
       excludeModules: [
         excludeModule,
@@ -2029,6 +2031,7 @@ describe('services/configurations:plugins', () => {
           key: 'file.key',
           cert: 'file.cert',
         },
+        proxied: {},
       },
       excludeModules: [
         excludeModule,
@@ -2483,6 +2486,1006 @@ describe('services/configurations:plugins', () => {
     });
   });
 
+  it('should generate the configurations with a dev server being proxied', () => {
+    // Given
+    // - key file
+    fs.pathExistsSync.mockImplementationOnce(() => true);
+    fs.readFileSync.mockImplementationOnce((filepath) => filepath);
+    // - cert file
+    fs.pathExistsSync.mockImplementationOnce(() => false);
+    const buildType = 'development';
+    const definitions = {
+      NODE_ENV: 'development',
+    };
+    const output = {
+      file: 'output-file',
+    };
+    const paths = {
+      js: 'js-path',
+      css: 'css-path',
+      fonts: 'fonts-path',
+      images: 'images-path',
+    };
+    const excludeModule = 'colors';
+    const target = {
+      css: {
+        modules: false,
+      },
+      paths: {
+        build: 'dist',
+      },
+      is: {
+        node: false,
+        browser: true,
+      },
+      html: {
+        filename: 'my-target.html',
+      },
+      devServer: {
+        host: 'localhost',
+        port: 2509,
+        ssl: {
+          key: 'file.key',
+          cert: 'file.cert',
+        },
+        proxied: {
+          enabled: true,
+          host: null,
+          https: null,
+        },
+      },
+      excludeModules: [
+        excludeModule,
+      ],
+    };
+    const rules = {
+      js: {
+        paths: {
+          include: ['js-paths-include'],
+          exclude: ['js-paths-exclude'],
+        },
+        files: {
+          glob: {
+            include: ['js-files-include-glob'],
+            exclude: ['js-files-exclude-glob'],
+          },
+        },
+      },
+      scss: {
+        files: {
+          include: ['scss-files-include-regex'],
+          exclude: ['scss-files-exclude-regex'],
+        },
+      },
+      css: {
+        files: {
+          include: ['css-files-include-regex'],
+          exclude: ['css-files-exclude-regex'],
+        },
+      },
+      commonFonts: {
+        files: {
+          include: ['common-fonts-files-include-regex'],
+          exclude: ['common-fonts-files-exclude-regex'],
+        },
+      },
+      svgFonts: {
+        files: {
+          include: ['svg-fonts-files-include-regex'],
+          exclude: ['svg-fonts-files-exclude-regex'],
+        },
+      },
+      images: {
+        files: {
+          include: ['images-files-include-regex'],
+          exclude: ['images-files-exclude-regex'],
+        },
+      },
+      favicon: {
+        files: {
+          include: ['favicon-files-include-regex'],
+          exclude: ['favicon-files-exclude-regex'],
+        },
+      },
+    };
+    const targetRules = {
+      js: {
+        getRule: jest.fn(() => rules.js),
+      },
+      scss: {
+        getRule: jest.fn(() => rules.scss),
+      },
+      css: {
+        getRule: jest.fn(() => rules.css),
+      },
+      fonts: {
+        common: {
+          getRule: jest.fn(() => rules.commonFonts),
+        },
+        svg: {
+          getRule: jest.fn(() => rules.svgFonts),
+        },
+      },
+      images: {
+        getRule: jest.fn(() => rules.images),
+      },
+      favicon: {
+        getRule: jest.fn(() => rules.favicon),
+      },
+    };
+    const copy = ['files-to-copy'];
+    const params = {
+      buildType,
+      definitions,
+      output,
+      paths,
+      target,
+      rules,
+      targetRules,
+      copy,
+    };
+    const stats = 'stats';
+
+    const appLogger = 'appLogger';
+    const babelConfig = {
+      babel: true,
+    };
+    const babelConfiguration = {
+      getConfigForTarget: jest.fn(() => babelConfig),
+    };
+    const babelHelper = {
+      disableEnvPresetModules: jest.fn((config) => Object.assign({}, config, { modules: false })),
+      addPlugin: jest.fn((config, plugin) => Object.assign({}, config, {
+        plugins: {
+          [plugin]: true,
+        },
+      })),
+    };
+    const events = {
+      reduce: jest.fn((eventName, configurationToReduce) => configurationToReduce),
+    };
+    const packageInfo = {
+      dependencies: {
+        jimpex: 'latest',
+      },
+      devDependencies: {
+        wootils: 'latest',
+        colors: 'next',
+      },
+    };
+    const pathUtils = {
+      join: jest.fn((rest) => rest),
+    };
+    const pluginName = 'plugin';
+    const rollupPluginInfo = {
+      name: pluginName,
+      external: [],
+    };
+    const htmlFile = 'index.html';
+    const targetsHTML = {
+      getFilepath: jest.fn(() => htmlFile),
+    };
+    let sut = null;
+    let result = null;
+    const expectedAssets = {
+      fonts: {
+        include: [
+          ...rules.commonFonts.files.include,
+          ...rules.svgFonts.files.include,
+        ],
+        exclude: [
+          ...rules.commonFonts.files.exclude,
+          ...rules.svgFonts.files.exclude,
+        ],
+        output: `${target.paths.build}/${paths.fonts}`,
+        url: `/${paths.fonts}`,
+      },
+      images: {
+        include: [...rules.images.files.include],
+        exclude: [...rules.images.files.exclude],
+        output: `${target.paths.build}/${paths.images}`,
+        url: `/${paths.images}`,
+      },
+      favicon: {
+        include: [...rules.favicon.files.include],
+        exclude: [...rules.favicon.files.exclude],
+        output: `${target.paths.build}/[name].[ext]`,
+        url: '/[name].[ext]',
+      },
+    };
+    const expectedSettings = {
+      external: {
+        external: [
+          excludeModule,
+        ],
+      },
+      globals: {
+        [excludeModule]: excludeModule,
+      },
+      resolve: {
+        extensions: ['.js', '.json', '.jsx'],
+        browser: true,
+        preferBuiltins: false,
+      },
+      replace: definitions,
+      babel: Object.assign({}, babelConfig, {
+        modules: false,
+        plugins: {
+          'external-helpers': true,
+        },
+        include: rules.js.files.glob.include,
+        exclude: rules.js.files.glob.exclude,
+      }),
+      commonjs: {
+        include: [
+          /config/i,
+          /node_modules\//i,
+        ],
+      },
+      sass: {
+        include: rules.scss.files.include,
+        exclude: rules.scss.files.exclude,
+        runtime: 'node-sass',
+        options: {
+          sourceMapEmbed: true,
+          outputStyle: 'compressed',
+          includePaths: ['node_modules'],
+          data: '',
+        },
+        failOnError: true,
+        processor: expect.any(Function),
+        output: `${target.paths.build}/${paths.css}`,
+      },
+      css: {
+        include: rules.css.files.include,
+        exclude: rules.css.files.exclude,
+        processor: expect.any(Function),
+        stats,
+        output: `${target.paths.build}/${paths.css}`,
+      },
+      stylesheetAssets: {
+        stylesheet: `${target.paths.build}/${paths.css}`,
+        stats,
+        urls: [
+          expectedAssets.fonts,
+          expectedAssets.images,
+        ],
+      },
+      stylesheetModulesFixer: {
+        include: [
+          ...rules.scss.files.include,
+          ...rules.css.files.include,
+        ],
+        exclude: [
+          ...rules.scss.files.exclude,
+          ...rules.css.files.exclude,
+        ],
+      },
+      html: {},
+      json: {},
+      urls: {
+        urls: [
+          expectedAssets.fonts,
+          expectedAssets.images,
+          expectedAssets.favicon,
+        ],
+        stats,
+      },
+      watch: {
+        clearScreen: false,
+      },
+      uglify: {},
+      compression: {
+        folder: target.paths.build,
+        include: [expect.any(RegExp)],
+        exclude: [],
+        stats,
+      },
+      copy: {
+        files: copy,
+        stats,
+      },
+      statsLog: {
+        extraEntries: [
+          {
+            plugin: 'rollup',
+            filepath: `${target.paths.build}/${paths.js}`,
+          },
+          {
+            plugin: 'rollup-plugin-sass',
+            filepath: `${target.paths.build}/${paths.css}`,
+          },
+        ],
+      },
+      template: {
+        template: htmlFile,
+        output: `${target.paths.build}/${target.html.filename}`,
+        stylesheets: [`/${paths.css}`],
+        scripts: [`/${paths.js}`],
+        urls: [
+          expectedAssets.images,
+          expectedAssets.favicon,
+        ],
+        stats,
+      },
+      devServer: {
+        host: target.devServer.host,
+        port: target.devServer.port,
+        contentBase: target.paths.build,
+        historyApiFallback: false,
+        open: false,
+        https: {
+          key: target.devServer.ssl.key,
+        },
+        logger: appLogger,
+        proxied: {
+          host: target.devServer.host,
+          https: true,
+        },
+      },
+    };
+    const expectedEvents = [
+      {
+        events: [
+          'rollup-external-plugin-settings-configuration-for-browser',
+          'rollup-external-plugin-settings-configuration',
+        ],
+        settings: expectedSettings.external,
+      },
+      {
+        events: [
+          'rollup-global-variables-settings-configuration-for-browser',
+          'rollup-global-variables-settings-configuration',
+        ],
+        settings: expectedSettings.globals,
+      },
+      {
+        events: [
+          'rollup-resolve-plugin-settings-configuration-for-browser',
+          'rollup-resolve-plugin-settings-configuration',
+        ],
+        settings: expectedSettings.resolve,
+      },
+      {
+        events: [
+          'rollup-replace-plugin-settings-configuration-for-browser',
+          'rollup-replace-plugin-settings-configuration',
+        ],
+        settings: expectedSettings.replace,
+      },
+      {
+        events: [
+          'rollup-babel-plugin-settings-configuration-for-browser',
+          'rollup-babel-plugin-settings-configuration',
+        ],
+        settings: expectedSettings.babel,
+      },
+      {
+        events: [
+          'rollup-commonjs-plugin-settings-configuration-for-browser',
+          'rollup-commonjs-plugin-settings-configuration',
+        ],
+        settings: expectedSettings.commonjs,
+      },
+      {
+        events: [
+          'rollup-sass-plugin-settings-configuration-for-browser',
+          'rollup-sass-plugin-settings-configuration',
+        ],
+        settings: expectedSettings.sass,
+      },
+      {
+        events: [
+          'rollup-css-plugin-settings-configuration-for-browser',
+          'rollup-css-plugin-settings-configuration',
+        ],
+        settings: expectedSettings.css,
+      },
+      {
+        events: [
+          'rollup-stylesheet-assets-plugin-settings-configuration-for-browser',
+          'rollup-stylesheet-assets-plugin-settings-configuration',
+        ],
+        settings: expectedSettings.stylesheetAssets,
+      },
+      {
+        events: [
+          'rollup-stylesheet-modules-fixer-plugin-settings-configuration-for-browser',
+          'rollup-stylesheet-modules-fixer-plugin-settings-configuration',
+        ],
+        settings: expectedSettings.stylesheetModulesFixer,
+      },
+      {
+        events: [
+          'rollup-html-plugin-settings-configuration-for-browser',
+          'rollup-html-plugin-settings-configuration',
+        ],
+        settings: expectedSettings.html,
+      },
+      {
+        events: [
+          'rollup-json-plugin-settings-configuration-for-browser',
+          'rollup-json-plugin-settings-configuration',
+        ],
+        settings: expectedSettings.json,
+      },
+      {
+        events: [
+          'rollup-urls-plugin-settings-configuration-for-browser',
+          'rollup-urls-plugin-settings-configuration',
+        ],
+        settings: expectedSettings.urls,
+      },
+      {
+        events: [
+          'rollup-watch-plugin-settings-configuration-for-browser',
+          'rollup-watch-plugin-settings-configuration',
+        ],
+        settings: expectedSettings.watch,
+      },
+      {
+        events: [
+          'rollup-uglify-plugin-settings-configuration-for-browser',
+          'rollup-uglify-plugin-settings-configuration',
+        ],
+        settings: expectedSettings.uglify,
+      },
+      {
+        events: [
+          'rollup-compression-plugin-settings-configuration-for-browser',
+          'rollup-compression-plugin-settings-configuration',
+        ],
+        settings: expectedSettings.compression,
+      },
+      {
+        events: [
+          'rollup-copy-plugin-settings-configuration-for-browser',
+          'rollup-copy-plugin-settings-configuration',
+        ],
+        settings: expectedSettings.copy,
+      },
+      {
+        events: [
+          'rollup-stats-plugin-settings-configuration-for-browser',
+          'rollup-stats-plugin-settings-configuration',
+        ],
+        settings: expectedSettings.statsLog,
+      },
+      {
+        events: 'rollup-template-plugin-settings-configuration',
+        settings: expectedSettings.template,
+      },
+      {
+        events: 'rollup-dev-server-plugin-settings-configuration',
+        settings: expectedSettings.devServer,
+      },
+      {
+        events: [
+          'rollup-plugin-settings-configuration-for-browser',
+          'rollup-plugin-settings-configuration',
+        ],
+        settings: expectedSettings,
+      },
+    ];
+    // When
+    sut = new RollupPluginSettingsConfiguration(
+      appLogger,
+      babelConfiguration,
+      babelHelper,
+      events,
+      packageInfo,
+      pathUtils,
+      rollupPluginInfo,
+      targetsHTML
+    );
+    result = sut.getConfig(params, stats);
+    // Then
+    expect(result).toEqual(expectedSettings);
+    expect(events.reduce).toHaveBeenCalledTimes(expectedEvents.length);
+    expectedEvents.forEach((event) => {
+      expect(events.reduce).toHaveBeenCalledWith(
+        event.events,
+        event.settings,
+        params
+      );
+    });
+  });
+
+  it('should generate the configurations with a server being proxied with custom SSL host', () => {
+    // Given
+    const buildType = 'development';
+    const definitions = {
+      NODE_ENV: 'development',
+    };
+    const output = {
+      file: 'output-file',
+    };
+    const paths = {
+      js: 'js-path',
+      css: 'css-path',
+      fonts: 'fonts-path',
+      images: 'images-path',
+    };
+    const excludeModule = 'colors';
+    const target = {
+      css: {
+        modules: false,
+      },
+      paths: {
+        build: 'dist',
+      },
+      is: {
+        node: false,
+        browser: true,
+      },
+      html: {
+        filename: 'my-target.html',
+      },
+      devServer: {
+        host: 'localhost',
+        port: 2509,
+        ssl: {},
+        proxied: {
+          enabled: true,
+          host: 'my-proxied-domain.com',
+          https: true,
+        },
+      },
+      excludeModules: [
+        excludeModule,
+      ],
+    };
+    const rules = {
+      js: {
+        paths: {
+          include: ['js-paths-include'],
+          exclude: ['js-paths-exclude'],
+        },
+        files: {
+          glob: {
+            include: ['js-files-include-glob'],
+            exclude: ['js-files-exclude-glob'],
+          },
+        },
+      },
+      scss: {
+        files: {
+          include: ['scss-files-include-regex'],
+          exclude: ['scss-files-exclude-regex'],
+        },
+      },
+      css: {
+        files: {
+          include: ['css-files-include-regex'],
+          exclude: ['css-files-exclude-regex'],
+        },
+      },
+      commonFonts: {
+        files: {
+          include: ['common-fonts-files-include-regex'],
+          exclude: ['common-fonts-files-exclude-regex'],
+        },
+      },
+      svgFonts: {
+        files: {
+          include: ['svg-fonts-files-include-regex'],
+          exclude: ['svg-fonts-files-exclude-regex'],
+        },
+      },
+      images: {
+        files: {
+          include: ['images-files-include-regex'],
+          exclude: ['images-files-exclude-regex'],
+        },
+      },
+      favicon: {
+        files: {
+          include: ['favicon-files-include-regex'],
+          exclude: ['favicon-files-exclude-regex'],
+        },
+      },
+    };
+    const targetRules = {
+      js: {
+        getRule: jest.fn(() => rules.js),
+      },
+      scss: {
+        getRule: jest.fn(() => rules.scss),
+      },
+      css: {
+        getRule: jest.fn(() => rules.css),
+      },
+      fonts: {
+        common: {
+          getRule: jest.fn(() => rules.commonFonts),
+        },
+        svg: {
+          getRule: jest.fn(() => rules.svgFonts),
+        },
+      },
+      images: {
+        getRule: jest.fn(() => rules.images),
+      },
+      favicon: {
+        getRule: jest.fn(() => rules.favicon),
+      },
+    };
+    const copy = ['files-to-copy'];
+    const params = {
+      buildType,
+      definitions,
+      output,
+      paths,
+      target,
+      rules,
+      targetRules,
+      copy,
+    };
+    const stats = 'stats';
+
+    const appLogger = 'appLogger';
+    const babelConfig = {
+      babel: true,
+    };
+    const babelConfiguration = {
+      getConfigForTarget: jest.fn(() => babelConfig),
+    };
+    const babelHelper = {
+      disableEnvPresetModules: jest.fn((config) => Object.assign({}, config, { modules: false })),
+      addPlugin: jest.fn((config, plugin) => Object.assign({}, config, {
+        plugins: {
+          [plugin]: true,
+        },
+      })),
+    };
+    const events = {
+      reduce: jest.fn((eventName, configurationToReduce) => configurationToReduce),
+    };
+    const packageInfo = {
+      dependencies: {
+        jimpex: 'latest',
+      },
+      devDependencies: {
+        wootils: 'latest',
+        colors: 'next',
+      },
+    };
+    const pathUtils = {
+      join: jest.fn((rest) => rest),
+    };
+    const pluginName = 'plugin';
+    const rollupPluginInfo = {
+      name: pluginName,
+      external: [],
+    };
+    const htmlFile = 'index.html';
+    const targetsHTML = {
+      getFilepath: jest.fn(() => htmlFile),
+    };
+    let sut = null;
+    let result = null;
+    const expectedAssets = {
+      fonts: {
+        include: [
+          ...rules.commonFonts.files.include,
+          ...rules.svgFonts.files.include,
+        ],
+        exclude: [
+          ...rules.commonFonts.files.exclude,
+          ...rules.svgFonts.files.exclude,
+        ],
+        output: `${target.paths.build}/${paths.fonts}`,
+        url: `/${paths.fonts}`,
+      },
+      images: {
+        include: [...rules.images.files.include],
+        exclude: [...rules.images.files.exclude],
+        output: `${target.paths.build}/${paths.images}`,
+        url: `/${paths.images}`,
+      },
+      favicon: {
+        include: [...rules.favicon.files.include],
+        exclude: [...rules.favicon.files.exclude],
+        output: `${target.paths.build}/[name].[ext]`,
+        url: '/[name].[ext]',
+      },
+    };
+    const expectedSettings = {
+      external: {
+        external: [
+          excludeModule,
+        ],
+      },
+      globals: {
+        [excludeModule]: excludeModule,
+      },
+      resolve: {
+        extensions: ['.js', '.json', '.jsx'],
+        browser: true,
+        preferBuiltins: false,
+      },
+      replace: definitions,
+      babel: Object.assign({}, babelConfig, {
+        modules: false,
+        plugins: {
+          'external-helpers': true,
+        },
+        include: rules.js.files.glob.include,
+        exclude: rules.js.files.glob.exclude,
+      }),
+      commonjs: {
+        include: [
+          /config/i,
+          /node_modules\//i,
+        ],
+      },
+      sass: {
+        include: rules.scss.files.include,
+        exclude: rules.scss.files.exclude,
+        runtime: 'node-sass',
+        options: {
+          sourceMapEmbed: true,
+          outputStyle: 'compressed',
+          includePaths: ['node_modules'],
+          data: '',
+        },
+        failOnError: true,
+        processor: expect.any(Function),
+        output: `${target.paths.build}/${paths.css}`,
+      },
+      css: {
+        include: rules.css.files.include,
+        exclude: rules.css.files.exclude,
+        processor: expect.any(Function),
+        stats,
+        output: `${target.paths.build}/${paths.css}`,
+      },
+      stylesheetAssets: {
+        stylesheet: `${target.paths.build}/${paths.css}`,
+        stats,
+        urls: [
+          expectedAssets.fonts,
+          expectedAssets.images,
+        ],
+      },
+      stylesheetModulesFixer: {
+        include: [
+          ...rules.scss.files.include,
+          ...rules.css.files.include,
+        ],
+        exclude: [
+          ...rules.scss.files.exclude,
+          ...rules.css.files.exclude,
+        ],
+      },
+      html: {},
+      json: {},
+      urls: {
+        urls: [
+          expectedAssets.fonts,
+          expectedAssets.images,
+          expectedAssets.favicon,
+        ],
+        stats,
+      },
+      watch: {
+        clearScreen: false,
+      },
+      uglify: {},
+      compression: {
+        folder: target.paths.build,
+        include: [expect.any(RegExp)],
+        exclude: [],
+        stats,
+      },
+      copy: {
+        files: copy,
+        stats,
+      },
+      statsLog: {
+        extraEntries: [
+          {
+            plugin: 'rollup',
+            filepath: `${target.paths.build}/${paths.js}`,
+          },
+          {
+            plugin: 'rollup-plugin-sass',
+            filepath: `${target.paths.build}/${paths.css}`,
+          },
+        ],
+      },
+      template: {
+        template: htmlFile,
+        output: `${target.paths.build}/${target.html.filename}`,
+        stylesheets: [`/${paths.css}`],
+        scripts: [`/${paths.js}`],
+        urls: [
+          expectedAssets.images,
+          expectedAssets.favicon,
+        ],
+        stats,
+      },
+      devServer: {
+        host: target.devServer.host,
+        port: target.devServer.port,
+        contentBase: target.paths.build,
+        historyApiFallback: false,
+        open: false,
+        https: null,
+        logger: appLogger,
+        proxied: {
+          host: target.devServer.proxied.host,
+          https: target.devServer.proxied.https,
+        },
+      },
+    };
+    const expectedEvents = [
+      {
+        events: [
+          'rollup-external-plugin-settings-configuration-for-browser',
+          'rollup-external-plugin-settings-configuration',
+        ],
+        settings: expectedSettings.external,
+      },
+      {
+        events: [
+          'rollup-global-variables-settings-configuration-for-browser',
+          'rollup-global-variables-settings-configuration',
+        ],
+        settings: expectedSettings.globals,
+      },
+      {
+        events: [
+          'rollup-resolve-plugin-settings-configuration-for-browser',
+          'rollup-resolve-plugin-settings-configuration',
+        ],
+        settings: expectedSettings.resolve,
+      },
+      {
+        events: [
+          'rollup-replace-plugin-settings-configuration-for-browser',
+          'rollup-replace-plugin-settings-configuration',
+        ],
+        settings: expectedSettings.replace,
+      },
+      {
+        events: [
+          'rollup-babel-plugin-settings-configuration-for-browser',
+          'rollup-babel-plugin-settings-configuration',
+        ],
+        settings: expectedSettings.babel,
+      },
+      {
+        events: [
+          'rollup-commonjs-plugin-settings-configuration-for-browser',
+          'rollup-commonjs-plugin-settings-configuration',
+        ],
+        settings: expectedSettings.commonjs,
+      },
+      {
+        events: [
+          'rollup-sass-plugin-settings-configuration-for-browser',
+          'rollup-sass-plugin-settings-configuration',
+        ],
+        settings: expectedSettings.sass,
+      },
+      {
+        events: [
+          'rollup-css-plugin-settings-configuration-for-browser',
+          'rollup-css-plugin-settings-configuration',
+        ],
+        settings: expectedSettings.css,
+      },
+      {
+        events: [
+          'rollup-stylesheet-assets-plugin-settings-configuration-for-browser',
+          'rollup-stylesheet-assets-plugin-settings-configuration',
+        ],
+        settings: expectedSettings.stylesheetAssets,
+      },
+      {
+        events: [
+          'rollup-stylesheet-modules-fixer-plugin-settings-configuration-for-browser',
+          'rollup-stylesheet-modules-fixer-plugin-settings-configuration',
+        ],
+        settings: expectedSettings.stylesheetModulesFixer,
+      },
+      {
+        events: [
+          'rollup-html-plugin-settings-configuration-for-browser',
+          'rollup-html-plugin-settings-configuration',
+        ],
+        settings: expectedSettings.html,
+      },
+      {
+        events: [
+          'rollup-json-plugin-settings-configuration-for-browser',
+          'rollup-json-plugin-settings-configuration',
+        ],
+        settings: expectedSettings.json,
+      },
+      {
+        events: [
+          'rollup-urls-plugin-settings-configuration-for-browser',
+          'rollup-urls-plugin-settings-configuration',
+        ],
+        settings: expectedSettings.urls,
+      },
+      {
+        events: [
+          'rollup-watch-plugin-settings-configuration-for-browser',
+          'rollup-watch-plugin-settings-configuration',
+        ],
+        settings: expectedSettings.watch,
+      },
+      {
+        events: [
+          'rollup-uglify-plugin-settings-configuration-for-browser',
+          'rollup-uglify-plugin-settings-configuration',
+        ],
+        settings: expectedSettings.uglify,
+      },
+      {
+        events: [
+          'rollup-compression-plugin-settings-configuration-for-browser',
+          'rollup-compression-plugin-settings-configuration',
+        ],
+        settings: expectedSettings.compression,
+      },
+      {
+        events: [
+          'rollup-copy-plugin-settings-configuration-for-browser',
+          'rollup-copy-plugin-settings-configuration',
+        ],
+        settings: expectedSettings.copy,
+      },
+      {
+        events: [
+          'rollup-stats-plugin-settings-configuration-for-browser',
+          'rollup-stats-plugin-settings-configuration',
+        ],
+        settings: expectedSettings.statsLog,
+      },
+      {
+        events: 'rollup-template-plugin-settings-configuration',
+        settings: expectedSettings.template,
+      },
+      {
+        events: 'rollup-dev-server-plugin-settings-configuration',
+        settings: expectedSettings.devServer,
+      },
+      {
+        events: [
+          'rollup-plugin-settings-configuration-for-browser',
+          'rollup-plugin-settings-configuration',
+        ],
+        settings: expectedSettings,
+      },
+    ];
+    // When
+    sut = new RollupPluginSettingsConfiguration(
+      appLogger,
+      babelConfiguration,
+      babelHelper,
+      events,
+      packageInfo,
+      pathUtils,
+      rollupPluginInfo,
+      targetsHTML
+    );
+    result = sut.getConfig(params, stats);
+    // Then
+    expect(result).toEqual(expectedSettings);
+    expect(events.reduce).toHaveBeenCalledTimes(expectedEvents.length);
+    expectedEvents.forEach((event) => {
+      expect(events.reduce).toHaveBeenCalledWith(
+        event.events,
+        event.settings,
+        params
+      );
+    });
+  });
+
   it('should generate the plugins configuration for a browser target with source map', () => {
     // Given
     const buildType = 'development';
@@ -2517,6 +3520,7 @@ describe('services/configurations:plugins', () => {
         host: 'localhost',
         port: 2509,
         ssl: {},
+        proxied: {},
       },
       sourceMap: {
         [buildType]: true,
@@ -3012,6 +4016,7 @@ describe('services/configurations:plugins', () => {
         host: 'localhost',
         port: 2509,
         ssl: {},
+        proxied: {},
       },
       excludeModules: [
         excludeModule,
@@ -3226,6 +4231,7 @@ describe('services/configurations:plugins', () => {
         host: 'localhost',
         port: 2509,
         ssl: {},
+        proxied: {},
       },
       excludeModules: [
         excludeModule,
@@ -3436,6 +4442,7 @@ describe('services/configurations:plugins', () => {
         host: 'localhost',
         port: 2509,
         ssl: {},
+        proxied: {},
       },
       excludeModules: [
         excludeModule,


### PR DESCRIPTION
### What does this PR do?

While I was working on homer0/projext-plugin-webpack#54, I realized that the dev server plugin I made for Rollup doesn't take in account the target `devServer.proxied` settings, so even if you declare a proxied host, the plugin will always open and log the URL of the base config.

This PR solves the issue by adding support on the plugin for the `proxied` settings, and at the same time it updates the `pluginsConfiguration` service so it will generate them.

### How should it be tested manually?

You can test it with a configuration like this one:

```js
{
  ...
  devServer: {
    proxied: {
      enabled: true,
      host: 'my-local-domain.com',
      https: true,
    },
    port: 2525,
  },
}
```

When you run your target for development, instead of opening `http://localhost:2525`, it should open `https://my-local-domain.com` (Up to you to setup `my-local-domain` on your computer with SSL enabled :P).

And of course...

```bash
npm test
# or
yarn test
```
