### PR TITLE
TypeScript support

### DIFF
--- a/src/plugins/stylesheetAssets/index.js
+++ b/src/plugins/stylesheetAssets/index.js
@@ -78,7 +78,7 @@ class ProjextRollupStylesheetAssetsPlugin {
      */
     this._expressions = {
       url: /url\s*\(\s*(?:['|"])?(\.\.?\/.*?)(?:['|"])?\)/ig,
-      js: /\.jsx?$/i,
+      js: /\.[jt]sx?$/i,
       fullMap: /(\/\*# sourceMappingURL=[\w:/]+;base64,((?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?) \*\/)/ig,
     };
     /**

--- a/src/services/configurations/pluginsConfiguration.js
+++ b/src/services/configurations/pluginsConfiguration.js
@@ -246,7 +246,7 @@ class RollupPluginSettingsConfiguration extends ConfigurationFile {
     const { target } = params;
     const settings = {
       // Add just for basic JS files and JSON.
-      extensions: ['.js', '.json', '.jsx'],
+      extensions: ['.js', '.json', '.jsx', '.ts', '.tsx'],
       browser: target.is.browser,
       preferBuiltins: target.is.node,
     };
@@ -1140,6 +1140,8 @@ class RollupPluginSettingsConfiguration extends ConfigurationFile {
     const extensions = [
       'js',
       'jsx',
+      'ts',
+      'tsx',
       'css',
       'html',
       'map',

--- a/src/services/configurations/pluginsConfiguration.js
+++ b/src/services/configurations/pluginsConfiguration.js
@@ -318,6 +318,7 @@ class RollupPluginSettingsConfiguration extends ConfigurationFile {
       {},
       configuration,
       {
+        extensions: ['.js', '.jsx', '.ts', '.tsx'],
         // The plugin doesn't support RegExp, so it will use the glob patterns.
         include: [...jsRule.files.glob.include],
         exclude: [...jsRule.files.glob.exclude],

--- a/tests/services/configurations/pluginsConfiguration.test.js
+++ b/tests/services/configurations/pluginsConfiguration.test.js
@@ -274,7 +274,7 @@ describe('services/configurations:plugins', () => {
       },
       globals: expectedGlobals,
       resolve: {
-        extensions: ['.js', '.json', '.jsx'],
+        extensions: ['.js', '.json', '.jsx', '.ts', '.tsx'],
         browser: false,
         preferBuiltins: true,
       },
@@ -746,7 +746,7 @@ describe('services/configurations:plugins', () => {
       },
       globals: expectedGlobals,
       resolve: {
-        extensions: ['.js', '.json', '.jsx'],
+        extensions: ['.js', '.json', '.jsx', '.ts', '.tsx'],
         browser: false,
         preferBuiltins: true,
       },
@@ -1220,7 +1220,7 @@ describe('services/configurations:plugins', () => {
         [excludeModule]: excludeModule,
       },
       resolve: {
-        extensions: ['.js', '.json', '.jsx'],
+        extensions: ['.js', '.json', '.jsx', '.ts', '.tsx'],
         browser: true,
         preferBuiltins: false,
       },
@@ -1705,7 +1705,7 @@ describe('services/configurations:plugins', () => {
         [excludeModule]: excludeModule,
       },
       resolve: {
-        extensions: ['.js', '.json', '.jsx'],
+        extensions: ['.js', '.json', '.jsx', '.ts', '.tsx'],
         browser: true,
         preferBuiltins: false,
       },
@@ -2193,7 +2193,7 @@ describe('services/configurations:plugins', () => {
         [excludeModule]: excludeModule,
       },
       resolve: {
-        extensions: ['.js', '.json', '.jsx'],
+        extensions: ['.js', '.json', '.jsx', '.ts', '.tsx'],
         browser: true,
         preferBuiltins: false,
       },
@@ -2691,7 +2691,7 @@ describe('services/configurations:plugins', () => {
         [excludeModule]: excludeModule,
       },
       resolve: {
-        extensions: ['.js', '.json', '.jsx'],
+        extensions: ['.js', '.json', '.jsx', '.ts', '.tsx'],
         browser: true,
         preferBuiltins: false,
       },
@@ -3185,7 +3185,7 @@ describe('services/configurations:plugins', () => {
         [excludeModule]: excludeModule,
       },
       resolve: {
-        extensions: ['.js', '.json', '.jsx'],
+        extensions: ['.js', '.json', '.jsx', '.ts', '.tsx'],
         browser: true,
         preferBuiltins: false,
       },
@@ -3676,7 +3676,7 @@ describe('services/configurations:plugins', () => {
         [excludeModule]: excludeModule,
       },
       resolve: {
-        extensions: ['.js', '.json', '.jsx'],
+        extensions: ['.js', '.json', '.jsx', '.ts', '.tsx'],
         browser: true,
         preferBuiltins: false,
       },

--- a/tests/services/configurations/pluginsConfiguration.test.js
+++ b/tests/services/configurations/pluginsConfiguration.test.js
@@ -281,6 +281,7 @@ describe('services/configurations:plugins', () => {
       replace: definitions,
       babel: Object.assign({}, babelConfig, {
         modules: false,
+        extensions: ['.js', '.jsx', '.ts', '.tsx'],
         include: rules.js.files.glob.include,
         exclude: rules.js.files.glob.exclude,
       }),
@@ -753,6 +754,7 @@ describe('services/configurations:plugins', () => {
       replace: definitions,
       babel: Object.assign({}, babelConfig, {
         modules: false,
+        extensions: ['.js', '.jsx', '.ts', '.tsx'],
         include: rules.js.files.glob.include,
         exclude: rules.js.files.glob.exclude,
       }),
@@ -1227,6 +1229,7 @@ describe('services/configurations:plugins', () => {
       replace: definitions,
       babel: Object.assign({}, babelConfig, {
         modules: false,
+        extensions: ['.js', '.jsx', '.ts', '.tsx'],
         include: rules.js.files.glob.include,
         exclude: rules.js.files.glob.exclude,
       }),
@@ -1712,6 +1715,7 @@ describe('services/configurations:plugins', () => {
       replace: definitions,
       babel: Object.assign({}, babelConfig, {
         modules: false,
+        extensions: ['.js', '.jsx', '.ts', '.tsx'],
         include: rules.js.files.glob.include,
         exclude: rules.js.files.glob.exclude,
       }),
@@ -2200,6 +2204,7 @@ describe('services/configurations:plugins', () => {
       replace: definitions,
       babel: Object.assign({}, babelConfig, {
         modules: false,
+        extensions: ['.js', '.jsx', '.ts', '.tsx'],
         include: rules.js.files.glob.include,
         exclude: rules.js.files.glob.exclude,
       }),
@@ -2698,6 +2703,7 @@ describe('services/configurations:plugins', () => {
       replace: definitions,
       babel: Object.assign({}, babelConfig, {
         modules: false,
+        extensions: ['.js', '.jsx', '.ts', '.tsx'],
         include: rules.js.files.glob.include,
         exclude: rules.js.files.glob.exclude,
       }),
@@ -3192,6 +3198,7 @@ describe('services/configurations:plugins', () => {
       replace: definitions,
       babel: Object.assign({}, babelConfig, {
         modules: false,
+        extensions: ['.js', '.jsx', '.ts', '.tsx'],
         include: rules.js.files.glob.include,
         exclude: rules.js.files.glob.exclude,
       }),
@@ -3683,6 +3690,7 @@ describe('services/configurations:plugins', () => {
       replace: definitions,
       babel: Object.assign({}, babelConfig, {
         modules: false,
+        extensions: ['.js', '.jsx', '.ts', '.tsx'],
         include: rules.js.files.glob.include,
         exclude: rules.js.files.glob.exclude,
       }),


### PR DESCRIPTION
### What does this PR do?

This is the webpack implementation of homer0/projext#64.

The good news is that, since the TypeScript transformation is being handled by Babel and the types declarations are being generated by projext, the only thing needed on this plugin was to add the `.ts` and `.tsx` extensions to all the Rollup plugins that resolved files.

### How should it be tested manually?

Obviously, try bundling a TypeScript target, and then...

```bash
yarn test
# or
npm test
```
