### PR TITLE
feat(services/building/configuration): load targets dotenv files

### DIFF
--- a/src/services/building/configuration.js
+++ b/src/services/building/configuration.js
@@ -135,10 +135,18 @@ class RollupConfiguration {
    * @ignore
    */
   _getDefinitions(target, env) {
-    const definitions = {
-      'process.env.NODE_ENV': `'${env}'`,
-      [this.buildVersion.getDefinitionVariable()]: JSON.stringify(this.buildVersion.getVersion()),
-    };
+    const targetVariables = this.targets.loadTargetDotEnvFile(target, env);
+    const definitions = Object.keys(targetVariables).reduce(
+      (current, variableName) => Object.assign({}, current, {
+        [`process.env.${variableName}`]: JSON.stringify(targetVariables[variableName]),
+      }),
+      {}
+    );
+
+    definitions['process.env.NODE_ENV'] = `'${env}'`;
+    definitions[this.buildVersion.getDefinitionVariable()] = JSON.stringify(
+      this.buildVersion.getVersion()
+    );
 
     if (
       target.is.browser &&

--- a/tests/services/building/configuration.test.js
+++ b/tests/services/building/configuration.test.js
@@ -45,7 +45,9 @@ describe('services/building:configuration', () => {
   it('should throw an error when trying to build a target with an invalid type', () => {
     // Given
     const buildVersion = 'buildVersion';
-    const targets = 'targets';
+    const targets = {
+      loadTargetDotEnvFile: jest.fn(() => ({})),
+    };
     const targetsFileRules = 'targetsFileRules';
     const targetConfiguration = 'targetConfiguration';
     const target = {
@@ -69,7 +71,9 @@ describe('services/building:configuration', () => {
   it('should throw an error when trying to build with an unknown build type', () => {
     // Given
     const buildVersion = 'buildVersion';
-    const targets = 'targets';
+    const targets = {
+      loadTargetDotEnvFile: jest.fn(() => ({})),
+    };
     const targetsFileRules = 'targetsFileRules';
     const targetConfiguration = 'targetConfiguration';
     const target = {
@@ -109,7 +113,13 @@ describe('services/building:configuration', () => {
     const targetConfig = {
       getConfig: jest.fn(() => config),
     };
-    const targets = 'targets';
+    const envVarName = 'ROSARIO';
+    const envVarValue = 'Charito';
+    const targets = {
+      loadTargetDotEnvFile: jest.fn(() => ({
+        [envVarName]: envVarValue,
+      })),
+    };
     const targetRules = 'target-rule';
     const targetsFileRules = {
       getRulesForTarget: jest.fn(() => targetRules),
@@ -174,6 +184,8 @@ describe('services/building:configuration', () => {
       `rollup/${target.name}.${buildType}.config.js`,
       targetConfig
     );
+    expect(targets.loadTargetDotEnvFile).toHaveBeenCalledTimes(1);
+    expect(targets.loadTargetDotEnvFile).toHaveBeenCalledWith(target, buildType);
     expect(targetConfig.getConfig).toHaveBeenCalledTimes(1);
     expect(targetConfig.getConfig).toHaveBeenCalledWith({
       input: path.join(target.paths.source, target.entry[buildType]),
@@ -187,6 +199,7 @@ describe('services/building:configuration', () => {
       buildType,
       targetRules,
       definitions: {
+        [`process.env.${envVarName}`]: `"${envVarValue}"`,
         'process.env.NODE_ENV': `'${buildType}'`,
         [versionVariable]: `"${version}"`,
       },
@@ -214,6 +227,7 @@ describe('services/building:configuration', () => {
     const filesToCopy = ['copy'];
     const targets = {
       getFilesToCopy: jest.fn(() => filesToCopy),
+      loadTargetDotEnvFile: jest.fn(() => ({})),
     };
     const targetRules = 'target-rule';
     const targetsFileRules = {
@@ -280,6 +294,8 @@ describe('services/building:configuration', () => {
       `rollup/${target.name}.${buildType}.config.js`,
       targetConfig
     );
+    expect(targets.loadTargetDotEnvFile).toHaveBeenCalledTimes(1);
+    expect(targets.loadTargetDotEnvFile).toHaveBeenCalledWith(target, buildType);
     expect(targetConfig.getConfig).toHaveBeenCalledTimes(1);
     expect(targetConfig.getConfig).toHaveBeenCalledWith({
       input: path.join(target.paths.source, target.entry[buildType]),
@@ -322,6 +338,7 @@ describe('services/building:configuration', () => {
     const filesToCopy = ['copy'];
     const targets = {
       getFilesToCopy: jest.fn(() => filesToCopy),
+      loadTargetDotEnvFile: jest.fn(() => ({})),
     };
     const targetRules = 'target-rule';
     const targetsFileRules = {
@@ -389,6 +406,8 @@ describe('services/building:configuration', () => {
       `rollup/${target.name}.${buildType}.config.js`,
       targetConfig
     );
+    expect(targets.loadTargetDotEnvFile).toHaveBeenCalledTimes(1);
+    expect(targets.loadTargetDotEnvFile).toHaveBeenCalledWith(target, buildType);
     expect(targetConfig.getConfig).toHaveBeenCalledTimes(1);
     expect(targetConfig.getConfig).toHaveBeenCalledWith({
       input: path.join(target.paths.source, target.entry[buildType]),
@@ -437,6 +456,7 @@ describe('services/building:configuration', () => {
     const filesToCopy = ['copy'];
     const targets = {
       getFilesToCopy: jest.fn(() => filesToCopy),
+      loadTargetDotEnvFile: jest.fn(() => ({})),
     };
     const targetRules = 'target-rule';
     const targetsFileRules = {
@@ -500,6 +520,8 @@ describe('services/building:configuration', () => {
       `rollup/${target.name}.${buildType}.config.js`,
       targetConfig
     );
+    expect(targets.loadTargetDotEnvFile).toHaveBeenCalledTimes(1);
+    expect(targets.loadTargetDotEnvFile).toHaveBeenCalledWith(target, buildType);
     expect(targetConfig.getConfig).toHaveBeenCalledTimes(1);
     expect(targetConfig.getConfig).toHaveBeenCalledWith({
       input: path.join(target.paths.source, target.entry[buildType]),
@@ -544,6 +566,7 @@ describe('services/building:configuration', () => {
     const filesToCopy = ['copy'];
     const targets = {
       getFilesToCopy: jest.fn(() => filesToCopy),
+      loadTargetDotEnvFile: jest.fn(() => ({})),
     };
     const targetRules = 'target-rule';
     const targetsFileRules = {
@@ -608,6 +631,8 @@ describe('services/building:configuration', () => {
       `rollup/${target.name}.${buildType}.config.js`,
       targetConfig
     );
+    expect(targets.loadTargetDotEnvFile).toHaveBeenCalledTimes(1);
+    expect(targets.loadTargetDotEnvFile).toHaveBeenCalledWith(target, buildType);
     expect(targetConfig.getConfig).toHaveBeenCalledTimes(1);
     expect(targetConfig.getConfig).toHaveBeenCalledWith({
       input: path.join(target.paths.source, target.entry[buildType]),
@@ -656,6 +681,7 @@ describe('services/building:configuration', () => {
     const targets = {
       getBrowserTargetConfiguration: jest.fn(() => targetBrowserConfig),
       getFilesToCopy: jest.fn(() => filesToCopy),
+      loadTargetDotEnvFile: jest.fn(() => ({})),
     };
     const targetRules = 'target-rule';
     const targetsFileRules = {
@@ -719,6 +745,8 @@ describe('services/building:configuration', () => {
       `rollup/${target.name}.${buildType}.config.js`,
       targetConfig
     );
+    expect(targets.loadTargetDotEnvFile).toHaveBeenCalledTimes(1);
+    expect(targets.loadTargetDotEnvFile).toHaveBeenCalledWith(target, buildType);
     expect(targetConfig.getConfig).toHaveBeenCalledTimes(1);
     expect(targetConfig.getConfig).toHaveBeenCalledWith({
       input: path.join(target.paths.source, target.entry[buildType]),
@@ -763,7 +791,9 @@ describe('services/building:configuration', () => {
     const targetConfig = {
       getConfig: jest.fn(() => config),
     };
-    const targets = 'targets';
+    const targets = {
+      loadTargetDotEnvFile: jest.fn(() => ({})),
+    };
     const targetRules = 'target-rule';
     const targetsFileRules = {
       getRulesForTarget: jest.fn(() => targetRules),
@@ -836,6 +866,8 @@ describe('services/building:configuration', () => {
       `rollup/${target.name}.${buildType}.config.js`,
       targetConfig
     );
+    expect(targets.loadTargetDotEnvFile).toHaveBeenCalledTimes(1);
+    expect(targets.loadTargetDotEnvFile).toHaveBeenCalledWith(target, buildType);
     expect(targetConfig.getConfig).toHaveBeenCalledTimes(1);
     expect(targetConfig.getConfig).toHaveBeenCalledWith({
       input: path.join(target.paths.source, target.entry[buildType]),
@@ -880,6 +912,7 @@ describe('services/building:configuration', () => {
     const filesToCopy = ['copy'];
     const targets = {
       getFilesToCopy: jest.fn(() => filesToCopy),
+      loadTargetDotEnvFile: jest.fn(() => ({})),
     };
     const targetRules = 'target-rule';
     const targetsFileRules = {
@@ -957,6 +990,8 @@ describe('services/building:configuration', () => {
       `rollup/${target.name}.${buildType}.config.js`,
       targetConfig
     );
+    expect(targets.loadTargetDotEnvFile).toHaveBeenCalledTimes(1);
+    expect(targets.loadTargetDotEnvFile).toHaveBeenCalledWith(target, buildType);
     expect(targetConfig.getConfig).toHaveBeenCalledTimes(1);
     expect(targetConfig.getConfig).toHaveBeenCalledWith({
       input: path.join(target.paths.source, target.entry[buildType]),
@@ -1000,7 +1035,9 @@ describe('services/building:configuration', () => {
     const targetConfig = {
       getConfig: jest.fn(() => config),
     };
-    const targets = 'targets';
+    const targets = {
+      loadTargetDotEnvFile: jest.fn(() => ({})),
+    };
     const targetRules = 'target-rule';
     const targetsFileRules = {
       getRulesForTarget: jest.fn(() => targetRules),
@@ -1077,6 +1114,8 @@ describe('services/building:configuration', () => {
       `rollup/${target.name}.${buildType}.config.js`,
       targetConfig
     );
+    expect(targets.loadTargetDotEnvFile).toHaveBeenCalledTimes(1);
+    expect(targets.loadTargetDotEnvFile).toHaveBeenCalledWith(target, buildType);
     expect(targetConfig.getConfig).toHaveBeenCalledTimes(1);
     expect(targetConfig.getConfig).toHaveBeenCalledWith({
       input: path.join(target.paths.source, target.entry[buildType]),


### PR DESCRIPTION
### What does this PR do?

> This is the implementation of homer0/projext#80.
> 
> It add supports for targets' `.env` files.

When creating the definitions that end up on `rollup-plugin-replace`, `RollupConfiguration` will now include the variables from the `.env` files.

### How should it be tested manually?

In order to test this, you need to install `homer0/projext#next` and make sure you delete the copy of `projext` `npm`/`yarn` will install inside this package's `node_modules`.

Create an `.env.[target-name]` file with a variable declaration and then log it on your target using `process.env.[VARIABLE-NAME]`.

And, of course...

```bash
yarn test
# or
npm test
```