### PR TITLE
feat(project): watch files involved in the creation of a browser target configuration

### DIFF
--- a/src/services/building/configuration.js
+++ b/src/services/building/configuration.js
@@ -103,15 +103,24 @@ class RollupConfiguration {
       copy.push(...this.targets.getFilesToCopy(target, buildType));
     }
 
+    const definitions = this._getDefinitions(target, buildType);
+    const additionalWatch = [];
+    if (target.is.browser && target.configuration && target.configuration.enabled) {
+      const browserConfig = this.targets.getBrowserTargetConfiguration(target);
+      definitions[target.configuration.defineOn] = JSON.stringify(browserConfig.configuration);
+      additionalWatch.push(...browserConfig.files);
+    }
+
     const params = {
       input,
       output,
       target,
       targetRules: this.targetsFileRules.getRulesForTarget(target),
-      definitions: this._getDefinitions(target, buildType),
+      definitions,
       buildType,
       paths,
       copy,
+      additionalWatch,
     };
 
     let config = this.targetConfiguration(
@@ -147,16 +156,6 @@ class RollupConfiguration {
     definitions[this.buildVersion.getDefinitionVariable()] = JSON.stringify(
       this.buildVersion.getVersion()
     );
-
-    if (
-      target.is.browser &&
-      target.configuration &&
-      target.configuration.enabled
-    ) {
-      definitions[target.configuration.defineOn] = JSON.stringify(
-        this.targets.getBrowserTargetConfiguration(target)
-      );
-    }
 
     return definitions;
   }

--- a/src/services/configurations/pluginsConfiguration.js
+++ b/src/services/configurations/pluginsConfiguration.js
@@ -780,6 +780,7 @@ class RollupPluginSettingsConfiguration extends ConfigurationFile {
     // Define the plugin settings.
     const settings = {
       clearScreen: false,
+      include: params.additionalWatch,
     };
 
     const eventName = params.target.is.node ?

--- a/src/typedef.js
+++ b/src/typedef.js
@@ -536,24 +536,27 @@
 
 /**
  * @typedef {Object} RollupConfigurationParams
- * @property {string}                          input       The path for the entry file.
- * @property {RollupConfigurationOutputParams} output      The Rollup settings for the bundle
- *                                                         generation.
- * @property {Target}                          target      The information of the target being
- *                                                         bundled.
- * @property {TargetFileRules}                 targetRules The rules to find the different file
- *                                                         types a target may use.
- * @property {Object}                          definitions A dictionary of defined variables that
- *                                                         will be replaced on the bundled code.
- * @property {string}                          buildType   The intended build type: `development`
- *                                                         or `production`.
- * @property {RollupConfigurationPathsParams}  paths       A dictionary with the filenames formats
- *                                                         and paths of the different files the
- *                                                         bundle can generate.
- * @property {Array}                           copy        A list of
- *                                                         {@link TargetExtraFile} with
- *                                                         the information of files that need to
- *                                                         be copied during the bundling process.
+ * @property {string} input
+ * The path for the entry file.
+ * @property {RollupConfigurationOutputParams} output
+ * The Rollup settings for the bundle generation.
+ * @property {Target} target
+ * The information of the target being bundled.
+ * @property {TargetFileRules} targetRules
+ * The rules to find the different file types a target may use.
+ * @property {Object} definitions
+ * A dictionary of defined variables that will be replaced on the bundled code.
+ * @property {string} buildType
+ * The intended build type: `development` or `production`.
+ * @property {RollupConfigurationPathsParams} paths
+ * A dictionary with the filenames formats and paths of the different files the bundle can
+ * generate.
+ * @property {Array} copy
+ * A list of {@link TargetExtraFile} with the information of files that need to be copied during
+ * the bundling process.
+ * @property {Array} additionalWatch
+ * A list of additional paths webpack should watch for in order to restart the bundle.
+ */
 
 /**
  * @typedef {Object} RollupPluginInfo
@@ -564,7 +567,6 @@
  *                                  them.
  * @property {string} babelPolyfill The name of the file that imports the required modules to
  *                                  act as the old Babel polyfill.
-
  */
 
 /**

--- a/tests/services/building/configuration.test.js
+++ b/tests/services/building/configuration.test.js
@@ -205,6 +205,7 @@ describe('services/building:configuration', () => {
       },
       paths: target.output[buildType],
       copy: [],
+      additionalWatch: [],
     });
   });
 
@@ -314,6 +315,7 @@ describe('services/building:configuration', () => {
       },
       paths: target.output[buildType],
       copy: filesToCopy,
+      additionalWatch: [],
     });
     expect(targets.getFilesToCopy).toHaveBeenCalledTimes(1);
     expect(targets.getFilesToCopy).toHaveBeenCalledWith(target, buildType);
@@ -430,6 +432,7 @@ describe('services/building:configuration', () => {
         jsChunks: target.output[buildType].js.replace(/\.js$/, '.[name].js'),
       }),
       copy: filesToCopy,
+      additionalWatch: [],
     });
     expect(targets.getFilesToCopy).toHaveBeenCalledTimes(1);
     expect(targets.getFilesToCopy).toHaveBeenCalledWith(target, buildType);
@@ -540,6 +543,7 @@ describe('services/building:configuration', () => {
       },
       paths: target.output[buildType],
       copy: filesToCopy,
+      additionalWatch: [],
     });
     expect(targets.getFilesToCopy).toHaveBeenCalledTimes(1);
     expect(targets.getFilesToCopy).toHaveBeenCalledWith(target, buildType);
@@ -653,6 +657,7 @@ describe('services/building:configuration', () => {
       },
       paths: target.output[buildType],
       copy: filesToCopy,
+      additionalWatch: [],
     });
     expect(targets.getFilesToCopy).toHaveBeenCalledTimes(1);
     expect(targets.getFilesToCopy).toHaveBeenCalledWith(target, buildType);
@@ -674,12 +679,16 @@ describe('services/building:configuration', () => {
     const targetConfig = {
       getConfig: jest.fn(() => config),
     };
+    const targetBrowserConfigFiles = ['some-config-file'];
     const targetBrowserConfig = {
       someProp: 'someValue',
     };
     const filesToCopy = ['copy'];
     const targets = {
-      getBrowserTargetConfiguration: jest.fn(() => targetBrowserConfig),
+      getBrowserTargetConfiguration: jest.fn(() => ({
+        configuration: targetBrowserConfig,
+        files: targetBrowserConfigFiles,
+      })),
       getFilesToCopy: jest.fn(() => filesToCopy),
       loadTargetDotEnvFile: jest.fn(() => ({})),
     };
@@ -766,6 +775,7 @@ describe('services/building:configuration', () => {
       },
       paths: target.output[buildType],
       copy: filesToCopy,
+      additionalWatch: targetBrowserConfigFiles,
     });
     expect(targets.getBrowserTargetConfiguration).toHaveBeenCalledTimes(1);
     expect(targets.getBrowserTargetConfiguration).toHaveBeenCalledWith(target);
@@ -887,6 +897,7 @@ describe('services/building:configuration', () => {
       },
       paths: target.output[buildType],
       copy: [],
+      additionalWatch: [],
     });
   });
 
@@ -1011,6 +1022,7 @@ describe('services/building:configuration', () => {
       },
       paths: target.output[buildType],
       copy: filesToCopy,
+      additionalWatch: [],
     });
     expect(targets.getFilesToCopy).toHaveBeenCalledTimes(1);
     expect(targets.getFilesToCopy).toHaveBeenCalledWith(target, buildType);
@@ -1135,6 +1147,7 @@ describe('services/building:configuration', () => {
       },
       paths: target.output[buildType],
       copy: [],
+      additionalWatch: [],
     });
   });
 

--- a/tests/services/configurations/pluginsConfiguration.test.js
+++ b/tests/services/configurations/pluginsConfiguration.test.js
@@ -178,6 +178,7 @@ describe('services/configurations:plugins', () => {
       },
     };
     const copy = ['files-to-copy'];
+    const additionalWatch = ['file-to-watch'];
     const params = {
       buildType,
       definitions,
@@ -187,6 +188,7 @@ describe('services/configurations:plugins', () => {
       rules,
       targetRules,
       copy,
+      additionalWatch,
     };
     const stats = 'stats';
     const appLogger = 'appLogger';
@@ -344,6 +346,7 @@ describe('services/configurations:plugins', () => {
       },
       watch: {
         clearScreen: false,
+        include: additionalWatch,
       },
       uglify: {},
       compression: {
@@ -663,6 +666,7 @@ describe('services/configurations:plugins', () => {
       },
     };
     const copy = ['files-to-copy'];
+    const additionalWatch = ['file-to-watch'];
     const params = {
       buildType,
       definitions,
@@ -672,6 +676,7 @@ describe('services/configurations:plugins', () => {
       rules,
       targetRules,
       copy,
+      additionalWatch,
     };
     const stats = 'stats';
 
@@ -828,6 +833,7 @@ describe('services/configurations:plugins', () => {
       },
       watch: {
         clearScreen: false,
+        include: additionalWatch,
       },
       uglify: {},
       compression: {
@@ -1164,6 +1170,7 @@ describe('services/configurations:plugins', () => {
       },
     };
     const copy = ['files-to-copy'];
+    const additionalWatch = ['file-to-watch'];
     const params = {
       buildType,
       definitions,
@@ -1173,6 +1180,7 @@ describe('services/configurations:plugins', () => {
       rules,
       targetRules,
       copy,
+      additionalWatch,
     };
     const stats = 'stats';
 
@@ -1316,6 +1324,7 @@ describe('services/configurations:plugins', () => {
       },
       watch: {
         clearScreen: false,
+        include: additionalWatch,
       },
       uglify: {},
       compression: {
@@ -1656,6 +1665,7 @@ describe('services/configurations:plugins', () => {
       },
     };
     const copy = ['files-to-copy'];
+    const additionalWatch = ['file-to-watch'];
     const params = {
       buildType,
       definitions,
@@ -1665,6 +1675,7 @@ describe('services/configurations:plugins', () => {
       rules,
       targetRules,
       copy,
+      additionalWatch,
     };
     const stats = 'stats';
 
@@ -1813,6 +1824,7 @@ describe('services/configurations:plugins', () => {
       },
       watch: {
         clearScreen: false,
+        include: additionalWatch,
       },
       uglify: {},
       compression: {
@@ -2156,6 +2168,7 @@ describe('services/configurations:plugins', () => {
       },
     };
     const copy = ['files-to-copy'];
+    const additionalWatch = ['file-to-watch'];
     const params = {
       buildType,
       definitions,
@@ -2165,6 +2178,7 @@ describe('services/configurations:plugins', () => {
       rules,
       targetRules,
       copy,
+      additionalWatch,
     };
     const stats = 'stats';
 
@@ -2313,6 +2327,7 @@ describe('services/configurations:plugins', () => {
       },
       watch: {
         clearScreen: false,
+        include: additionalWatch,
       },
       uglify: {},
       compression: {
@@ -2666,6 +2681,7 @@ describe('services/configurations:plugins', () => {
       },
     };
     const copy = ['files-to-copy'];
+    const additionalWatch = ['file-to-watch'];
     const params = {
       buildType,
       definitions,
@@ -2675,6 +2691,7 @@ describe('services/configurations:plugins', () => {
       rules,
       targetRules,
       copy,
+      additionalWatch,
     };
     const stats = 'stats';
 
@@ -2823,6 +2840,7 @@ describe('services/configurations:plugins', () => {
       },
       watch: {
         clearScreen: false,
+        include: additionalWatch,
       },
       uglify: {},
       compression: {
@@ -3172,6 +3190,7 @@ describe('services/configurations:plugins', () => {
       },
     };
     const copy = ['files-to-copy'];
+    const additionalWatch = ['file-to-watch'];
     const params = {
       buildType,
       definitions,
@@ -3181,6 +3200,7 @@ describe('services/configurations:plugins', () => {
       rules,
       targetRules,
       copy,
+      additionalWatch,
     };
     const stats = 'stats';
 
@@ -3329,6 +3349,7 @@ describe('services/configurations:plugins', () => {
       },
       watch: {
         clearScreen: false,
+        include: additionalWatch,
       },
       uglify: {},
       compression: {
@@ -3675,6 +3696,7 @@ describe('services/configurations:plugins', () => {
       },
     };
     const copy = ['files-to-copy'];
+    const additionalWatch = ['file-to-watch'];
     const params = {
       buildType,
       definitions,
@@ -3684,6 +3706,7 @@ describe('services/configurations:plugins', () => {
       rules,
       targetRules,
       copy,
+      additionalWatch,
     };
     const stats = 'stats';
 
@@ -3832,6 +3855,7 @@ describe('services/configurations:plugins', () => {
       },
       watch: {
         clearScreen: false,
+        include: additionalWatch,
       },
       uglify: {},
       compression: {
@@ -4177,6 +4201,7 @@ describe('services/configurations:plugins', () => {
       },
     };
     const copy = ['files-to-copy'];
+    const additionalWatch = ['file-to-watch'];
     const params = {
       buildType,
       definitions,
@@ -4186,6 +4211,7 @@ describe('services/configurations:plugins', () => {
       rules,
       targetRules,
       copy,
+      additionalWatch,
     };
     const stats = 'stats';
 
@@ -4395,6 +4421,7 @@ describe('services/configurations:plugins', () => {
       },
     };
     const copy = ['files-to-copy'];
+    const additionalWatch = ['file-to-watch'];
     const params = {
       buildType,
       definitions,
@@ -4404,6 +4431,7 @@ describe('services/configurations:plugins', () => {
       rules,
       targetRules,
       copy,
+      additionalWatch,
     };
     const stats = 'stats';
 
@@ -4609,6 +4637,7 @@ describe('services/configurations:plugins', () => {
       },
     };
     const copy = ['files-to-copy'];
+    const additionalWatch = ['file-to-watch'];
     const params = {
       buildType,
       definitions,
@@ -4618,6 +4647,7 @@ describe('services/configurations:plugins', () => {
       rules,
       targetRules,
       copy,
+      additionalWatch,
     };
     const stats = 'stats';
 


### PR DESCRIPTION
### What does this PR do?

> This is the implementation of homer0/projext#82.

It watches the files involved on the creation of a "browser target configuration", so if they're modified, Rollup will reload the bundle.

### How should it be tested manually?

In order to test this, you need to install `homer0/projext#next` and make sure you delete the copy of `projext` `npm`/`yarn` will install inside this package's `node_modules`.

Create a browser target that uses a configuration file and try updating it while projext runs the target, the bundle should be reloaded.

And, of course...

```bash
yarn test
# or
npm test
```