### PR TITLE
feat(services/configuration/plugins): send the build type to the HTML generator

### DIFF
--- a/src/services/configurations/pluginsConfiguration.js
+++ b/src/services/configurations/pluginsConfiguration.js
@@ -790,12 +790,12 @@ class RollupPluginSettingsConfiguration extends ConfigurationFile {
    * @ignore
    */
   _getTemplateSettings(params, stats) {
-    const { target, paths } = params;
+    const { target, paths, buildType } = params;
     // Get the rules for common assets.
     const assetsRules = this._getAssetsRules(params);
     // Define the plugin settings.
     const settings = {
-      template: this.targetsHTML.getFilepath(target),
+      template: this.targetsHTML.getFilepath(target, false, buildType),
       output: `${target.paths.build}/${target.html.filename}`,
       stylesheets: target.css.inject ?
         [] :


### PR DESCRIPTION
### What does this PR do?

This is a follow up for homer0/projext#91, where the `targetsHTML` service added support for the build type to be sent as parameter.

This PR just sends adds the build type as the third parameter when calling `targetsHTML` on the HTML plugin configuration.

### How should it be tested manually?

In order to test this, you need to install `homer0/projext#next` and make sure you delete the copy of `projext` `npm`/`yarn` will install inside this package's `node_modules`... then you need to create a plugin, listen for `target-default-html-settings` and check if the third parameter is the build type... just run the tests:

```bash
yarn test
# or
npm test
```
