### PR TITLE
feat(services/building/configuration): reduce the configuration params using an event

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,8 +105,11 @@ All the configurations receive a single object parameter with the following prop
 - `input`: The path to the target entry file
 - `output`: The Rollup output settings for the target.
 - `paths`: A dictionary with the filenames formats and paths of the different files the bundle can generate (`js`, `css`, `images` and `fonts`).
-- `definitions`: A dictionary of defined variables that will be replaced on the bundled code.
+- `definitions`: A function that generates a dictionary of variables that will be replaced on the bundled code.
 - `buildType`: The indented build type (`development` or `production`).
+- `copy`: A list of information for files that need to be copied during the bundling process.
+- `additionalWatch`: A list of additional paths Rollup should watch for in order to restart the bundle.
+- `analyze`: A flag to detect if the bundled should be analyzed or not. 
 
 #### Plugins configuration
 
@@ -200,6 +203,13 @@ That change will only be applied when building the target `myApp` on a productio
 ## Making a plugin
 
 If you want to write a plugin that works with this one (like a framework plugin), there are a lot of reducer events you can listen for and use to modify the Rollup configuration:
+
+### Configuration parameters
+
+- Name: `rollup-configuration-parameters`
+- Reduces: The parameters used by the plugin services to build a target configuration.
+
+This is called before generating any configuration.
 
 ### Node target configuration
 

--- a/src/typedef.js
+++ b/src/typedef.js
@@ -555,7 +555,7 @@
  * A list of {@link TargetExtraFile} with the information of files that need to be copied during
  * the bundling process.
  * @property {Array} additionalWatch
- * A list of additional paths webpack should watch for in order to restart the bundle.
+ * A list of additional paths Rollup should watch for in order to restart the bundle.
  */
 
 /**


### PR DESCRIPTION
### What does this PR do?

Disclaimer: This is a development feature.

This adds a reducer event to reduce the "`params`" object the plugin uses all across the services to create the configurations.

The idea is that plugins and implementations can make use of this event to modify the information without having to listen for the actual configuration reducers.

It also does a little refactor on the same file where the feature was added in order to escape the `complexity` rule :P.

### How should it be tested manually?

Listen for the new event (and don't forget to return it at then of your listener) and, of course, run the tests:

```bash
yarn test
# or
npm test
```
