### PR TITLE
fix(plugins/stylesheetAssets): fix the error JSON parsing error for watch mode

### DIFF
--- a/src/services/configurations/pluginsConfiguration.js
+++ b/src/services/configurations/pluginsConfiguration.js
@@ -731,9 +731,9 @@ class RollupPluginSettingsConfiguration extends ConfigurationFile {
     );
   }
   /**
-   * Defines the settings for the `stylesheetAssets` plugin, which is a projext's plugin that
-   * transform files matching a filter by copying its contents into a new file on the output
-   * directory and replacing its default export with a URL for them.
+   * Defines the settings for the `urls` plugin, which is a projext's plugin that transforms
+   * files matching a filter and copies its contents into a new file on the output directory,
+   * then it replaces its default export with a URL for them.
    * This method uses the reducer event `rollup-urls-plugin-settings-configuration-for-browser` or
    * `rollup-urls-plugin-settings-configuration-for-node`, depending on the target type, and then
    * `rollup-urls-plugin-settings-configuration`. The event receives the settings, the `params`


### PR DESCRIPTION
### What does this PR do?

When Rollup is on watch mode, it caches file transformations but it's still triggered if you do "save" on an unmodified file, so... the build processes is triggered, but none of the transformations are called because nothing changed.

The problem was that the `stylesheetAssets` plugin was trying to obtain a source map from a file that wasn't processed, so it would throw an error.

The fix was simple, just check if the map exists before doing anything.

### How should it be tested manually?

While running/watching a target, **without changing anything**, press `ctrl`/`cmd`+`s` on a stylesheet file: on `master`, it should throw a JSON parse error, but on this branch, it shouldn't do it.

And of course...

```bash
yarn test
# or
npm test
```
