### PR TITLE
fix: fix code splitting support

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,6 +200,14 @@ module.exports = (params) => ({
 
 That change will only be applied when building the target `myApp` on a production build.
 
+### Code splitting
+
+Using code splitting with projext is quite simple, you can [read about it on the site](https://homer0.github.io/projext/manual/codeSplitting.html), but when it comes to Rollup, there's something you should be aware: The script tag for the bundle will use [`type="module"`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Modules).
+
+When you use code splitting with Rollup, Rollup will automatically take shared code between the chunks in order to create a "shared chunk", the "problem" is that the shared chunk is loaded using `import ... from '...'`, and when declared like that, `import` can only be used on scripts loaded using the `type="module"` attribute.
+
+This makes it impossible to target old browsers and implement code splitting at the same time, so it may be recommendable to use a direct implementation of Rollup, with different builds, or [the webpack build engine](https://yarnpkg.com/en/package/projext-plugin-webpack).
+
 ## Making a plugin
 
 If you want to write a plugin that works with this one (like a framework plugin), there are a lot of reducer events you can listen for and use to modify the Rollup configuration:
@@ -258,11 +266,11 @@ I use [Jest](https://facebook.github.io/jest/) with [Jest-Ex](https://yarnpkg.co
 
 ### Linting
 
-I use [ESlint](http://eslint.org) to validate all our JS code. The configuration file for the project code is on `./.eslintrc` and for the tests on `./tests/.eslintrc` (which inherits from the one on the root), there's also an `./.eslintignore` to ignore some files on the process, and the script that runs it is on `./utils/scripts/lint`.
+I use [ESlint](http://eslint.org) with [my own custom configuration](http://yarnpkg.com/en/package/eslint-plugin-homer0) to validate all the JS code. The configuration file for the project code is on `./.eslintrc` and for the tests on `./tests/.eslintrc`, there's also an `./.eslintignore` to ignore some files on the process, and the script that runs it is on `./utils/scripts/lint`.
 
 ### Documentation
 
-I use [ESDoc](http://esdoc.org) to generate HTML documentation for the project. The configuration file is on `./.esdocrc` and the script that runs it is on `./utils/scripts/docs`.
+I use [ESDoc](https://esdoc.org) to generate HTML documentation for the project. The configuration file is on `./.esdocrc` and the script that runs it is on `./utils/scripts/docs`.
 
 ### To-Dos
 

--- a/src/plugins/template/index.js
+++ b/src/plugins/template/index.js
@@ -114,7 +114,19 @@ class ProjextRollupTemplatePlugin {
     const async = this._options.scriptsAsync ? ' async="async"' : '';
     // Create all the script tags.
     const scripts = this._options.scripts
-    .map((url) => `<script type="text/javascript" src="${url}"${async}></script>`);
+    .map((url) => {
+      let script;
+      if (typeof url === 'string') {
+        script = `<script type="text/javascript" src="${url}"${async}></script>`;
+      } else if (!url.src) {
+        throw new Error(`${this.name}: Missing 'src' property on script object`);
+      } else {
+        const attributes = this._toHTMLAttributes(url);
+        script = `<script ${attributes}></script>`;
+      }
+
+      return script;
+    });
     // Create all the stylesheet links.
     const stylesheets = this._options.stylesheets
     .map((url) => `<link href="${url}" rel="stylesheet" />`);
@@ -255,6 +267,28 @@ class ProjextRollupTemplatePlugin {
     }
     // Return the final list.
     return result;
+  }
+  /**
+   * Transform a dictionary into a string of HTML attributes.
+   * @example
+   * _toHTMLAttributes({ w: 'x', y: 'z' });
+   * // w="x" y="z"
+   *
+   * @param {Object} obj The dictionary to transform.
+   * @return {String}
+   * @access protected
+   * @ignore
+   */
+  _toHTMLAttributes(obj) {
+    return Object.keys(obj)
+    .reduce(
+      (acc, name) => {
+        const value = `${obj[name]}`.replace(/"/, '\\"');
+        return [...acc, `${name}="${value}"`];
+      },
+      []
+    )
+    .join(' ');
   }
 }
 /**

--- a/src/plugins/windowAsGlobal/index.js
+++ b/src/plugins/windowAsGlobal/index.js
@@ -9,7 +9,11 @@ class ProjextRollupWindowAsGlobalPlugin {
    * @return {string}
    */
   intro() {
-    return 'var global = typeof window !== \'undefined\' ? window : {};';
+    return [
+      'if (typeof window !== \'undefined\' && typeof window.global === \'undefined\') {',
+      'window.global = window;',
+      '}',
+    ].join(' ');
   }
 }
 /**

--- a/src/services/configurations/pluginsConfiguration.js
+++ b/src/services/configurations/pluginsConfiguration.js
@@ -789,9 +789,19 @@ class RollupPluginSettingsConfiguration extends ConfigurationFile {
    * @ignore
    */
   _getTemplateSettings(params, stats) {
-    const { target, paths, buildType } = params;
+    const {
+      target,
+      paths,
+      buildType,
+      output,
+    } = params;
     // Get the rules for common assets.
     const assetsRules = this._getAssetsRules(params);
+    const script = {
+      src: `/${paths.js}`,
+      async: 'async',
+      type: output.format === 'es' ? 'module' : 'text/javascript',
+    };
     // Define the plugin settings.
     const settings = {
       template: this.targetsHTML.getFilepath(target, false, buildType),
@@ -799,7 +809,7 @@ class RollupPluginSettingsConfiguration extends ConfigurationFile {
       stylesheets: target.css.inject ?
         [] :
         [`/${paths.css}`],
-      scripts: [`/${paths.js}`],
+      scripts: [script],
       urls: [
         assetsRules.images,
         assetsRules.favicon,

--- a/tests/plugins/template/index.test.js
+++ b/tests/plugins/template/index.test.js
@@ -136,6 +136,55 @@ describe('plugins:template', () => {
     expect(fs.writeFileSync).toHaveBeenCalledWith(options.output, expectedCode);
   });
 
+  it('should generate a template with a JS file tag with custom attributes', () => {
+    // Given
+    const templateCode = '</head></body>';
+    fs.readFileSync.mockImplementationOnce(() => templateCode);
+    const script = {
+      type: 'module',
+      src: 'build.js',
+    };
+    const options = {
+      template: 'some-file.tpl',
+      output: 'dist/index.html',
+      scripts: [script],
+    };
+    let sut = null;
+    const expectedCode = [
+      '</head>',
+      `<script type="${script.type}" src="${script.src}"></script>\n`,
+      '</body>',
+    ]
+    .join('');
+    // When
+    sut = new ProjextRollupTemplatePlugin(options);
+    sut.writeBundle();
+    // Then
+    expect(fs.ensureDirSync).toHaveBeenCalledTimes(1);
+    expect(fs.ensureDirSync).toHaveBeenCalledWith(path.dirname(options.output));
+    expect(fs.writeFileSync).toHaveBeenCalledTimes(1);
+    expect(fs.writeFileSync).toHaveBeenCalledWith(options.output, expectedCode);
+  });
+
+  it('should throw an error when trying to generate a script tag without `src` attribute', () => {
+    // Given
+    const templateCode = '</head></body>';
+    fs.readFileSync.mockImplementationOnce(() => templateCode);
+    const script = {
+      type: 'module',
+    };
+    const options = {
+      template: 'some-file.tpl',
+      output: 'dist/index.html',
+      scripts: [script],
+    };
+    // When/Then
+    expect(() => (new ProjextRollupTemplatePlugin(options)).writeBundle())
+    .toThrow(/Missing 'src' property on script object/i);
+    expect(fs.ensureDirSync).toHaveBeenCalledTimes(0);
+    expect(fs.writeFileSync).toHaveBeenCalledTimes(0);
+  });
+
   it('should generate a template with a JS file on the head', () => {
     // Given
     const templateCode = '</head>';

--- a/tests/plugins/windowAsGlobal/index.test.js
+++ b/tests/plugins/windowAsGlobal/index.test.js
@@ -37,4 +37,66 @@ describe('plugins:windowAsGlobal', () => {
     expect(sut).toBeInstanceOf(ProjextRollupWindowAsGlobalPlugin);
     expect(sut.intro).toBeFunction();
   });
+
+  describe('code', () => {
+    it('should define `global` as an alias for `window`', () => {
+      // Given
+      let sut = null;
+      let code = null;
+      const fakeWindow = {};
+      // When
+      sut = new ProjextRollupWindowAsGlobalPlugin();
+      code = sut.intro();
+      ((function runCode() {
+        // eslint-disable-next-line no-unused-vars
+        const window = fakeWindow;
+        // eslint-disable-next-line no-eval
+        eval(code);
+      })());
+      // Then
+      expect(fakeWindow).toEqual({
+        global: fakeWindow,
+      });
+    });
+
+    it('shouldn\'t define `global` if `window.global` is it\'s already defined', () => {
+      // Given
+      let sut = null;
+      let code = null;
+      const fakeGlobal = 'some-fake-global';
+      const fakeWindow = { global: fakeGlobal };
+      // When
+      sut = new ProjextRollupWindowAsGlobalPlugin();
+      code = sut.intro();
+      ((function runCode() {
+        // eslint-disable-next-line no-unused-vars
+        const window = fakeWindow;
+        // eslint-disable-next-line no-eval
+        eval(code);
+      })());
+      // Then
+      expect(fakeWindow).toEqual({
+        global: fakeGlobal,
+      });
+    });
+
+    it('shouldn\'t define `global` if `window` is `undefined`', () => {
+      // Given
+      let sut = null;
+      let code = null;
+      const fakeWindowName = 'fake-window';
+      const fakeWindow = { name: fakeWindowName };
+      // When
+      sut = new ProjextRollupWindowAsGlobalPlugin();
+      code = sut.intro();
+      ((function runCode() {
+        // eslint-disable-next-line no-eval
+        eval(code);
+      })());
+      // Then
+      expect(fakeWindow).toEqual({
+        name: fakeWindowName,
+      });
+    });
+  });
 });

--- a/tests/services/configurations/pluginsConfiguration.test.js
+++ b/tests/services/configurations/pluginsConfiguration.test.js
@@ -1397,7 +1397,534 @@ describe('services/configurations:plugins', () => {
         template: htmlFile,
         output: `${target.paths.build}/${target.html.filename}`,
         stylesheets: [`/${paths.css}`],
-        scripts: [`/${paths.js}`],
+        scripts: [{
+          src: `/${paths.js}`,
+          type: 'text/javascript',
+          async: 'async',
+        }],
+        urls: [
+          expectedAssets.images,
+          expectedAssets.favicon,
+        ],
+        stats,
+      },
+      devServer: {
+        host: target.devServer.host,
+        port: target.devServer.port,
+        contentBase: target.paths.build,
+        historyApiFallback: false,
+        open: false,
+        https: null,
+        logger: appLogger,
+      },
+    };
+    const expectedEvents = [
+      {
+        events: [
+          'rollup-external-plugin-settings-configuration-for-browser',
+          'rollup-external-plugin-settings-configuration',
+        ],
+        settings: expectedSettings.external,
+      },
+      {
+        events: [
+          'rollup-global-variables-settings-configuration-for-browser',
+          'rollup-global-variables-settings-configuration',
+        ],
+        settings: expectedSettings.globals,
+      },
+      {
+        events: [
+          'rollup-resolve-plugin-settings-configuration-for-browser',
+          'rollup-resolve-plugin-settings-configuration',
+        ],
+        settings: expectedSettings.resolve,
+      },
+      {
+        events: [
+          'rollup-extra-watch-plugin-settings-configuration-for-browser',
+          'rollup-extra-watch-plugin-settings-configuration',
+        ],
+        settings: expectedSettings.extraWatch,
+      },
+      {
+        events: [
+          'rollup-module-replace-plugin-settings-configuration-for-browser',
+          'rollup-module-replace-plugin-settings-configuration',
+        ],
+        settings: expectedSettings.moduleReplace,
+      },
+      {
+        events: [
+          'rollup-babel-plugin-settings-configuration-for-browser',
+          'rollup-babel-plugin-settings-configuration',
+        ],
+        settings: expectedSettings.babel,
+      },
+      {
+        events: [
+          'rollup-commonjs-plugin-settings-configuration-for-browser',
+          'rollup-commonjs-plugin-settings-configuration',
+        ],
+        settings: expectedSettings.commonjs,
+      },
+      {
+        events: [
+          'rollup-sass-plugin-settings-configuration-for-browser',
+          'rollup-sass-plugin-settings-configuration',
+        ],
+        settings: expectedSettings.sass,
+      },
+      {
+        events: [
+          'rollup-css-plugin-settings-configuration-for-browser',
+          'rollup-css-plugin-settings-configuration',
+        ],
+        settings: expectedSettings.css,
+      },
+      {
+        events: [
+          'rollup-stylesheet-assets-plugin-settings-configuration-for-browser',
+          'rollup-stylesheet-assets-plugin-settings-configuration',
+        ],
+        settings: expectedSettings.stylesheetAssets,
+      },
+      {
+        events: [
+          'rollup-stylesheet-modules-fixer-plugin-settings-configuration-for-browser',
+          'rollup-stylesheet-modules-fixer-plugin-settings-configuration',
+        ],
+        settings: expectedSettings.stylesheetModulesFixer,
+      },
+      {
+        events: [
+          'rollup-html-plugin-settings-configuration-for-browser',
+          'rollup-html-plugin-settings-configuration',
+        ],
+        settings: expectedSettings.html,
+      },
+      {
+        events: [
+          'rollup-json-plugin-settings-configuration-for-browser',
+          'rollup-json-plugin-settings-configuration',
+        ],
+        settings: expectedSettings.json,
+      },
+      {
+        events: [
+          'rollup-urls-plugin-settings-configuration-for-browser',
+          'rollup-urls-plugin-settings-configuration',
+        ],
+        settings: expectedSettings.urls,
+      },
+      {
+        events: [
+          'rollup-watch-plugin-settings-configuration-for-browser',
+          'rollup-watch-plugin-settings-configuration',
+        ],
+        settings: expectedSettings.watch,
+      },
+      {
+        events: [
+          'rollup-terser-plugin-settings-configuration-for-browser',
+          'rollup-terser-plugin-settings-configuration',
+        ],
+        settings: expectedSettings.terser,
+      },
+      {
+        events: [
+          'rollup-compression-plugin-settings-configuration-for-browser',
+          'rollup-compression-plugin-settings-configuration',
+        ],
+        settings: expectedSettings.compression,
+      },
+      {
+        events: [
+          'rollup-copy-plugin-settings-configuration-for-browser',
+          'rollup-copy-plugin-settings-configuration',
+        ],
+        settings: expectedSettings.copy,
+      },
+      {
+        events: [
+          'rollup-visualizer-plugin-settings-configuration-for-browser',
+          'rollup-visualizer-plugin-settings-configuration',
+        ],
+        settings: expectedSettings.visualizer,
+      },
+      {
+        events: [
+          'rollup-stats-plugin-settings-configuration-for-browser',
+          'rollup-stats-plugin-settings-configuration',
+        ],
+        settings: expectedSettings.statsLog,
+      },
+      {
+        events: 'rollup-template-plugin-settings-configuration',
+        settings: expectedSettings.template,
+      },
+      {
+        events: 'rollup-dev-server-plugin-settings-configuration',
+        settings: expectedSettings.devServer,
+      },
+      {
+        events: [
+          'rollup-plugin-settings-configuration-for-browser',
+          'rollup-plugin-settings-configuration',
+        ],
+        settings: expectedSettings,
+      },
+    ];
+    // When
+    sut = new RollupPluginSettingsConfiguration(
+      appLogger,
+      babelConfiguration,
+      babelHelper,
+      events,
+      packageInfo,
+      pathUtils,
+      rollupPluginInfo,
+      targetsHTML
+    );
+    result = sut.getConfig(params, stats);
+    // Then
+    expect(result).toEqual(expectedSettings);
+    expect(events.reduce).toHaveBeenCalledTimes(expectedEvents.length);
+    expectedEvents.forEach((event) => {
+      expect(events.reduce).toHaveBeenCalledWith(
+        event.events,
+        event.settings,
+        params
+      );
+    });
+  });
+
+  it('should generate the plugins configuration for a browser target build with ESModules', () => {
+    // Given
+    const buildType = 'development';
+    const input = 'entry-file';
+    const output = {
+      file: 'output-file',
+      format: 'es',
+    };
+    const paths = {
+      js: 'js-path',
+      css: 'css-path',
+      fonts: 'fonts-path',
+      images: 'images-path',
+    };
+    const excludeModule = 'colors';
+    const pluginName = 'plugin';
+    const rollupPluginInfo = {
+      name: pluginName,
+      external: [],
+    };
+    const target = {
+      name: 'my-target',
+      css: {
+        modules: false,
+      },
+      paths: {
+        build: 'dist',
+      },
+      is: {
+        node: false,
+        browser: true,
+      },
+      html: {
+        filename: 'my-target.html',
+      },
+      devServer: {
+        host: 'localhost',
+        port: 2509,
+        ssl: {},
+        proxied: {},
+      },
+      excludeModules: [
+        excludeModule,
+      ],
+      sourceMap: {
+        [buildType]: false,
+      },
+    };
+    const rules = {
+      js: {
+        paths: {
+          include: ['js-paths-include'],
+          exclude: ['js-paths-exclude'],
+        },
+        files: {
+          glob: {
+            include: ['js-files-include-glob'],
+            exclude: ['js-files-exclude-glob'],
+          },
+        },
+      },
+      scss: {
+        files: {
+          include: ['scss-files-include-regex'],
+          exclude: ['scss-files-exclude-regex'],
+        },
+      },
+      css: {
+        files: {
+          include: ['css-files-include-regex'],
+          exclude: ['css-files-exclude-regex'],
+        },
+      },
+      commonFonts: {
+        files: {
+          include: ['common-fonts-files-include-regex'],
+          exclude: ['common-fonts-files-exclude-regex'],
+        },
+      },
+      svgFonts: {
+        files: {
+          include: ['svg-fonts-files-include-regex'],
+          exclude: ['svg-fonts-files-exclude-regex'],
+        },
+      },
+      images: {
+        files: {
+          include: ['images-files-include-regex'],
+          exclude: ['images-files-exclude-regex'],
+        },
+      },
+      favicon: {
+        files: {
+          include: ['favicon-files-include-regex'],
+          exclude: ['favicon-files-exclude-regex'],
+        },
+      },
+    };
+    const targetRules = {
+      js: {
+        getRule: jest.fn(() => rules.js),
+      },
+      scss: {
+        getRule: jest.fn(() => rules.scss),
+      },
+      css: {
+        getRule: jest.fn(() => rules.css),
+      },
+      fonts: {
+        common: {
+          getRule: jest.fn(() => rules.commonFonts),
+        },
+        svg: {
+          getRule: jest.fn(() => rules.svgFonts),
+        },
+      },
+      images: {
+        getRule: jest.fn(() => rules.images),
+      },
+      favicon: {
+        getRule: jest.fn(() => rules.favicon),
+      },
+    };
+    const copy = ['files-to-copy'];
+    const additionalWatch = ['file-to-watch'];
+    const params = {
+      buildType,
+      input,
+      output,
+      paths,
+      target,
+      rules,
+      targetRules,
+      copy,
+      additionalWatch,
+    };
+    const stats = 'stats';
+
+    const appLogger = 'appLogger';
+    const babelConfig = {
+      babel: true,
+    };
+    const babelConfiguration = {
+      getConfigForTarget: jest.fn(() => babelConfig),
+    };
+    const babelHelper = {
+      disableEnvPresetModules: jest.fn((config) => Object.assign({}, config, { modules: false })),
+      addPlugin: jest.fn((config, plugin) => Object.assign({}, config, {
+        plugins: {
+          [plugin]: true,
+        },
+      })),
+    };
+    const events = {
+      reduce: jest.fn((eventName, configurationToReduce) => configurationToReduce),
+    };
+    const packageInfo = {
+      dependencies: {
+        jimpex: 'latest',
+      },
+      devDependencies: {
+        wootils: 'latest',
+        colors: 'next',
+      },
+    };
+    const pathUtils = {
+      join: jest.fn((rest) => rest),
+    };
+    const htmlFile = 'index.html';
+    const targetsHTML = {
+      getFilepath: jest.fn(() => htmlFile),
+    };
+    let sut = null;
+    let result = null;
+    const expectedAssets = {
+      fonts: {
+        include: [
+          ...rules.commonFonts.files.include,
+          ...rules.svgFonts.files.include,
+        ],
+        exclude: [
+          ...rules.commonFonts.files.exclude,
+          ...rules.svgFonts.files.exclude,
+        ],
+        output: `${target.paths.build}/${paths.fonts}`,
+        url: `/${paths.fonts}`,
+      },
+      images: {
+        include: [...rules.images.files.include],
+        exclude: [...rules.images.files.exclude],
+        output: `${target.paths.build}/${paths.images}`,
+        url: `/${paths.images}`,
+      },
+      favicon: {
+        include: [...rules.favicon.files.include],
+        exclude: [...rules.favicon.files.exclude],
+        output: `${target.paths.build}/[name].[ext]`,
+        url: '/[name].[ext]',
+      },
+    };
+    const expectedSettings = {
+      external: {
+        external: [
+          excludeModule,
+        ],
+      },
+      globals: {
+        [excludeModule]: excludeModule,
+      },
+      resolve: {
+        extensions: ['.js', '.json', '.jsx', '.ts', '.tsx'],
+        browser: true,
+        preferBuiltins: false,
+      },
+      extraWatch: [
+        input,
+        ...additionalWatch,
+      ],
+      moduleReplace: {
+        instructions: [{
+          module: expect.any(RegExp),
+          search: expect.any(RegExp),
+          replace: expect.any(String),
+        }],
+        sourceMap: target.sourceMap[buildType],
+      },
+      babel: Object.assign({}, babelConfig, {
+        modules: false,
+        extensions: ['.js', '.jsx', '.ts', '.tsx'],
+        include: rules.js.files.glob.include,
+        exclude: rules.js.files.glob.exclude,
+      }),
+      commonjs: {
+        include: [
+          /config/i,
+          /node_modules\//i,
+        ],
+      },
+      sass: {
+        include: rules.scss.files.include,
+        exclude: rules.scss.files.exclude,
+        runtime: 'node-sass',
+        options: {
+          sourceMapEmbed: true,
+          outputStyle: 'compressed',
+          includePaths: ['node_modules'],
+          data: '',
+        },
+        failOnError: true,
+        processor: expect.any(Function),
+        output: `${target.paths.build}/${paths.css}`,
+      },
+      css: {
+        include: rules.css.files.include,
+        exclude: rules.css.files.exclude,
+        processor: expect.any(Function),
+        stats,
+        output: `${target.paths.build}/${paths.css}`,
+      },
+      stylesheetAssets: {
+        stylesheet: `${target.paths.build}/${paths.css}`,
+        stats,
+        urls: [
+          expectedAssets.fonts,
+          expectedAssets.images,
+        ],
+      },
+      stylesheetModulesFixer: {
+        include: [
+          ...rules.scss.files.include,
+          ...rules.css.files.include,
+        ],
+        exclude: [
+          ...rules.scss.files.exclude,
+          ...rules.css.files.exclude,
+        ],
+      },
+      html: {},
+      json: {},
+      urls: {
+        urls: [
+          expectedAssets.fonts,
+          expectedAssets.images,
+          expectedAssets.favicon,
+        ],
+        stats,
+      },
+      watch: {
+        clearScreen: false,
+      },
+      terser: {},
+      compression: {
+        folder: target.paths.build,
+        include: [expect.any(RegExp)],
+        exclude: [],
+        stats,
+      },
+      copy: {
+        files: copy,
+        stats,
+      },
+      visualizer: {
+        filename: `${target.paths.build}/${target.name}-stats-visualizer.html`,
+        open: true,
+      },
+      statsLog: {
+        extraEntries: [
+          {
+            plugin: 'rollup',
+            filepath: `${target.paths.build}/${paths.js}`,
+          },
+          {
+            plugin: 'rollup-plugin-sass',
+            filepath: `${target.paths.build}/${paths.css}`,
+          },
+        ],
+      },
+      template: {
+        template: htmlFile,
+        output: `${target.paths.build}/${target.html.filename}`,
+        stylesheets: [`/${paths.css}`],
+        scripts: [{
+          src: `/${paths.js}`,
+          type: 'module',
+          async: 'async',
+        }],
         urls: [
           expectedAssets.images,
           expectedAssets.favicon,
@@ -1912,7 +2439,11 @@ describe('services/configurations:plugins', () => {
         template: htmlFile,
         output: `${target.paths.build}/${target.html.filename}`,
         stylesheets: [],
-        scripts: [`/${paths.js}`],
+        scripts: [{
+          src: `/${paths.js}`,
+          type: 'text/javascript',
+          async: 'async',
+        }],
         urls: [
           expectedAssets.images,
           expectedAssets.favicon,
@@ -2438,7 +2969,11 @@ describe('services/configurations:plugins', () => {
         template: htmlFile,
         output: `${target.paths.build}/${target.html.filename}`,
         stylesheets: [`/${paths.css}`],
-        scripts: [`/${paths.js}`],
+        scripts: [{
+          src: `/${paths.js}`,
+          type: 'text/javascript',
+          async: 'async',
+        }],
         urls: [
           expectedAssets.images,
           expectedAssets.favicon,
@@ -2970,7 +3505,11 @@ describe('services/configurations:plugins', () => {
         template: htmlFile,
         output: `${target.paths.build}/${target.html.filename}`,
         stylesheets: [`/${paths.css}`],
-        scripts: [`/${paths.js}`],
+        scripts: [{
+          src: `/${paths.js}`,
+          type: 'text/javascript',
+          async: 'async',
+        }],
         urls: [
           expectedAssets.images,
           expectedAssets.favicon,
@@ -3498,7 +4037,11 @@ describe('services/configurations:plugins', () => {
         template: htmlFile,
         output: `${target.paths.build}/${target.html.filename}`,
         stylesheets: [`/${paths.css}`],
-        scripts: [`/${paths.js}`],
+        scripts: [{
+          src: `/${paths.js}`,
+          type: 'text/javascript',
+          async: 'async',
+        }],
         urls: [
           expectedAssets.images,
           expectedAssets.favicon,
@@ -4024,7 +4567,11 @@ describe('services/configurations:plugins', () => {
         template: htmlFile,
         output: `${target.paths.build}/${target.html.filename}`,
         stylesheets: [`/${paths.css}`],
-        scripts: [`/${paths.js}`],
+        scripts: [{
+          src: `/${paths.js}`,
+          type: 'text/javascript',
+          async: 'async',
+        }],
         urls: [
           expectedAssets.images,
           expectedAssets.favicon,


### PR DESCRIPTION
### What does this PR do?

When using code splitting with Rollup, Rollup automatically takes the shared imports from the chunks and creates a new "shared chunk". The "problem" is that the shared chunk is loaded using `import ... from '...'`, and when declared like that, `import` can only be used on scripts loaded using the `type="module"` attribute.

The solution was to use `type="module"` when code splitting was enabled: I added support for custom attributes for the `script` tag on the `template` plugin, and when creating the options for the plugin, if the output format is `es` (only used when there's code splitting), the `type` attribute changes from `text/javascript` to `module`.

This makes it impossible to target old browsers and implement code splitting at the same time, so it may be recommendable to use a direct implementation of Rollup, with different builds, or [the webpack build engine](https://yarnpkg.com/en/package/projext-plugin-webpack).

Also, while I testing the problem, I had the Babel polyfill enabled, and core-js has a file that defines `var global`, which was throwing error because of the `windowAsGlobal` plugin being injected as the first line of the bundle... so I optimized the plugin code a little bit and I even added some tests for the generated code.

### How should it be tested manually?

Similar to #50 , in order to test this, you need to mess with your npm/yarn installation:

1. Install `projext#next` from Github and this branch.
2. Delete the projext version installed inside this plugin `node_modules` (since this is not installed from a "proper version", `npm`/`yarn`, may install the one required by the plugin inside its directory: `node_modules/projext-plugin-rollup/node_modules/projext`).

Now, create a sample app with code splitting (you can use the one on the [samples repository](https://github.com/homer0/projext-samples/tree/master/rollup/basic)) and that should be enough: all polyfills will end up on a shared chunk.

The app should work and the `type` attribute of the script should be `module`.

Also...

```bash
npm test
# or
yarn test
```
